### PR TITLE
Use the newer license expression in the csproj

### DIFF
--- a/src/Namotion.Reflection/Namotion.Reflection.csproj
+++ b/src/Namotion.Reflection/Namotion.Reflection.csproj
@@ -8,7 +8,7 @@
     <Version>1.0.5</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageIconUrl>https://raw.githubusercontent.com/RicoSuter/Namotion.Reflection/master/assets/NuGetIcon.png</PackageIconUrl>
-    <PackageLicenseUrl>https://github.com/RicoSuter/Namotion.Reflection/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>.NET library with advanced reflection APIs like XML documentation reading, Null Reference Types (C# 8) reflection and string based type checks.</Description>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">


### PR DESCRIPTION
A project I work on uses https://clearlydefined.io to generate a third party notices file and it is having trouble detecting your license type.

They said that this change should help resolve the issue.

I'm assuming you don't have a nuspec that I didn't find.
I did the same thing for NJsonSchema here: https://github.com/RicoSuter/NJsonSchema/pull/881

Thanks