### PR TITLE
Patches/xml doc base classes

### DIFF
--- a/src/Namotion.Reflection.Cecil.Tests/Namotion.Reflection.Cecil.Tests.csproj
+++ b/src/Namotion.Reflection.Cecil.Tests/Namotion.Reflection.Cecil.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.10.3" />

--- a/src/Namotion.Reflection.Demo/Namotion.Reflection.Demo.csproj
+++ b/src/Namotion.Reflection.Demo/Namotion.Reflection.Demo.csproj
@@ -5,6 +5,7 @@
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Namotion.Reflection.Tests.FullAssembly/Namotion.Reflection.Tests.FullAssembly.csproj
+++ b/src/Namotion.Reflection.Tests.FullAssembly/Namotion.Reflection.Tests.FullAssembly.csproj
@@ -5,6 +5,7 @@
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="3.3.0-beta2-19380-06">

--- a/src/Namotion.Reflection.Tests/Namotion.Reflection.Tests.csproj
+++ b/src/Namotion.Reflection.Tests/Namotion.Reflection.Tests.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Net.Compilers" Version="3.3.0-beta2-19380-06">

--- a/src/Namotion.Reflection.Tests/XmlDocsExtensionsTests.cs
+++ b/src/Namotion.Reflection.Tests/XmlDocsExtensionsTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Drawing;
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -283,5 +285,65 @@ namespace Namotion.Reflection.Tests
             Assert.Equal("Foo", fooSummary);
             Assert.Equal("Bar", barSummary);
         }
+
+        public class BaseGenericClass<T>
+        {
+            /// <summary>
+            /// Single
+            /// </summary>
+            public T Single(T input)
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <summary>
+            /// Multi
+            /// </summary>
+            public ICollection<T> Multi(ICollection<T> input)
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <summary>
+            /// SingleAsync
+            /// </summary>
+            public Task<T> SingleAsync(T input)
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <summary>
+            /// MultiAsync
+            /// </summary>
+            public Task<ICollection<T>> MultiAsync(ICollection<T> input)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class InheritedGenericClass : BaseGenericClass<string>
+        {
+        }
+        
+#if !NETSTANDARD1_0
+        [Fact]
+        public void When_method_is_inherited_from_generic_class_then_xml_docs_are_correct()
+        {
+            //// Arrange
+            XmlDocs.ClearCache();
+
+            //// Act
+            var singleSummary = typeof(InheritedGenericClass).GetMethod(nameof(InheritedGenericClass.Single)).GetXmlDocsSummary();
+            var multiSummary = typeof(InheritedGenericClass).GetMethod(nameof(InheritedGenericClass.Multi)).GetXmlDocsSummary();
+            var singleAsyncSummary = typeof(InheritedGenericClass).GetMethod(nameof(InheritedGenericClass.SingleAsync)).GetXmlDocsSummary();
+            var multiAsyncSummary = typeof(InheritedGenericClass).GetMethod(nameof(InheritedGenericClass.MultiAsync)).GetXmlDocsSummary();
+
+            //// Assert
+            Assert.Equal("Single", singleSummary);
+            Assert.Equal("Multi", multiSummary);
+            Assert.Equal("SingleAsync", singleAsyncSummary);
+            Assert.Equal("MultiAsync", multiAsyncSummary);
+        }
+#endif
     }
 }


### PR DESCRIPTION
This partially fixes the Issue #8 .

This pull request fixes the issue where documentation from base generic classes is not seen when querying documentation for a derived class.

The root of the problem is that the XML documentation member name was generated based on the current class that the closed generic type it inherits from.

Status based on the frameworks:
* .Net Framework 4.0: Fixed
* .Net Framework 4.5: Fixed
* .Net Standard 2.0: Fixed
* .Net Standard 1.0: Not fixable
* Mono.Cecil: Fixable but todo.

For more details, see the Issue #8 
