### PR TITLE
Convert Xml nodes in `<remarks>` to Markdown

### DIFF
--- a/src/Namotion.Reflection.Tests/XmlDocsExtensionsMarkdownTests.cs
+++ b/src/Namotion.Reflection.Tests/XmlDocsExtensionsMarkdownTests.cs
@@ -1,0 +1,464 @@
+using Xunit;
+
+namespace Namotion.Reflection.Tests
+{
+    public class XmlDocsExtensionsMarkdownTests
+    {
+        /// <remarks>
+        /// Markdown support within remarks!
+        /// 
+        /// * OpenAPI 2 and 3 supports Markdown in `description`
+        /// * So you should be able to write documents in Markdown
+        ///     * Now you can write Markdown with NSwag!
+        ///     * You can
+        ///       <list type="bullet">
+        ///         <item>mix <c>XML</c> in <c>Markdown</c>
+        ///         </item>
+        ///         <item>It's cool</item>
+        ///         <item>
+        ///            Even you can
+        ///            <list type="number">
+        ///              <item>nest</item>
+        ///              <item>items</item>
+        ///            </list>
+        ///            yay!
+        ///         </item>
+        ///         <item>
+        ///         <code>
+        ///           you can even
+        ///           put code here
+        ///         </code>
+        ///         </item>
+        ///       </list>
+        ///     * return to the markdown
+        /// </remarks>
+        public class WithComplexMarkdownDoc
+        {
+        }
+
+        [Fact]
+        public void When_complex_xml_remarks_is_read_then_they_are_converted_to_markdown()
+        {
+            //// Arrange
+            XmlDocs.ClearCache();
+
+            //// Act
+            var summary = typeof(WithComplexMarkdownDoc).GetXmlDocsRemarks();
+
+            //// Assert
+            var expected = @"Markdown support within remarks!
+
+* OpenAPI 2 and 3 supports Markdown in `description`
+* So you should be able to write documents in Markdown
+    * Now you can write Markdown with NSwag!
+    * You can
+      * mix `XML` in `Markdown`
+      * It's cool
+      * Even you can
+        1. nest
+        2. items
+
+        yay!
+      * ```
+        you can even
+        put code here
+        ```
+    * return to the markdown".Replace("\r", "");
+            Assert.Equal(expected, summary);
+        }
+
+        /// <remarks>
+        /// <para>
+        ///   This <see cref="Assert"/> should be a code.
+        ///   This <see langword="null"/> is also a code.
+        ///   This <see href="http://github.com"/> is an autolink.
+        ///   <a href="http://github.com" title="Github">This</a> is a link.
+        /// </para>
+        /// </remarks>
+        public class SeeAndA
+        {
+        }
+
+        [Fact]
+        public void When_remarks_contains_see_and_a_then_they_are_converted_to_code_or_link()
+        {
+            //// Arrange
+            XmlDocs.ClearCache();
+
+            //// Act
+            var summary = typeof(SeeAndA).GetXmlDocsRemarks();
+
+            //// Assert
+            var expected = @"This `Assert` should be a code.
+This `null` is also a code.
+This <http://github.com> is an autolink.
+[This](http://github.com ""Github"") is a link.".Replace("\r", "");
+            Assert.Equal(expected, summary);
+        }
+
+        /// <remarks>
+        /// <para>
+        ///   Inline <c>code</c> is usually doesn't contain newlines.
+        ///   However Markdown allows <c>newline
+        ///     characters! and `some ```backticks </c>
+        ///   Although they are joined while they are rendered.
+        /// </para>
+        /// </remarks>
+        public class InlineCode
+        {
+        }
+
+        [Fact]
+        public void When_remarks_contains_c_then_they_are_converted_to_inline_code()
+        {
+            //// Arrange
+            XmlDocs.ClearCache();
+
+            //// Act
+            var summary = typeof(InlineCode).GetXmlDocsRemarks();
+
+            //// Assert
+            var expected = @"Inline `code` is usually doesn't contain newlines.
+However Markdown allows ``newline
+characters! and `some ```backticks ``
+Although they are joined while they are rendered.".Replace("\r", "");
+            Assert.Equal(expected, summary);
+        }
+
+        /// <remarks>
+        /// <para>
+        ///   <code lang="csharp">
+        ///      for (var i=0; i&lt;10; i++)
+        ///      {
+        ///        Console.WriteLine("Hello, World!");
+        ///      }
+        ///   </code>
+        /// 
+        ///   <code>
+        ///      Lang is an optional
+        ///   </code>
+        /// </para>
+        /// </remarks>
+        public class CodeBlock
+        {
+        }
+
+        [Fact]
+        public void When_remarks_contains_code_then_they_are_converted_to_code_block()
+        {
+            //// Arrange
+            XmlDocs.ClearCache();
+
+            //// Act
+            var summary = typeof(CodeBlock).GetXmlDocsRemarks();
+
+            //// Assert
+            var expected = @"```csharp
+for (var i=0; i<10; i++)
+{
+  Console.WriteLine(""Hello, World!"");
+}
+```
+
+```
+Lang is an optional
+```".Replace("\r", "");
+            Assert.Equal(expected, summary);
+        }
+
+        /// <remarks>
+        /// <para>
+        ///   <para> A para block makes block paragraph node.</para>
+        ///   <para>
+        ///      Subsequent paragraphs make hard newlines.
+        ///   </para>
+        /// </para>
+        /// </remarks>
+        public class Para
+        {
+        }
+
+        [Fact]
+        public void When_remarks_contains_para_then_they_are_converted_to_paragraph_node()
+        {
+            //// Arrange
+            XmlDocs.ClearCache();
+
+            //// Act
+            var summary = typeof(Para).GetXmlDocsRemarks();
+
+            //// Assert
+            var expected = @"A para block makes block paragraph node.
+
+Subsequent paragraphs make hard newlines.".Replace("\r", "");
+            Assert.Equal(expected, summary);
+        }
+
+        /// <remarks>
+        /// <para>
+        ///   <list type="table">
+        ///     <listheader>
+        ///       <term>Term</term>
+        ///       <description>Description</description>
+        ///     </listheader>
+        ///     <item>
+        ///       <term>Some term</term>
+        ///       <description>Some description with <c>code</c></description>
+        ///     </item>
+        ///   </list>
+        /// </para>
+        /// </remarks>
+        public class Table
+        {
+        }
+
+        [Fact]
+        public void When_remarks_contains_list_table_then_they_are_converted_to_table()
+        {
+            //// Arrange
+            XmlDocs.ClearCache();
+
+            //// Act
+            var summary = typeof(Table).GetXmlDocsRemarks();
+
+            //// Assert
+            var expected = @"| Term | Description |
+|---|---|
+| Some term | Some description with `code` |".Replace("\r", "");
+            Assert.Equal(expected, summary);
+        }
+
+        /// <remarks>
+        /// <para>
+        ///   <para>hard block</para><para>hard block</para>
+        ///   <para>hard block</para><code>soft block</code>
+        ///   <para>hard block</para><c>inline</c>
+        /// 
+        ///   <code>soft block</code><para>hard block</para>
+        ///   <code>soft block</code><code>soft block</code>
+        ///   <code>soft block</code><c>inline</c>
+        /// 
+        ///   <c>inline</c><para>hard block</para>
+        ///   <c>inline</c><code>soft block</code>
+        ///   <c>inline</c><c>inline</c>
+        /// </para>
+        /// </remarks>
+        public class BlockAndInlineAdjacent
+        {
+        }
+
+        [Fact]
+        public void When_block_inlines_adjacent_then_they_are_repels_heuristically()
+        {
+            //// Arrange
+            XmlDocs.ClearCache();
+
+            //// Act
+            var summary = typeof(BlockAndInlineAdjacent).GetXmlDocsRemarks();
+
+            //// Assert
+            var expected = @"hard block
+
+hard block
+
+hard block
+
+```
+soft block
+```
+hard block
+
+`inline`
+
+```
+soft block
+```
+hard block
+
+```
+soft block
+```
+```
+soft block
+```
+```
+soft block
+```
+`inline`
+
+`inline`
+hard block
+
+`inline`
+```
+soft block
+```
+`inline``inline`".Replace("\r", "");
+            Assert.Equal(expected, summary);
+        }
+
+        /// <remarks>
+        /// <para>
+        ///   <para>hard block</para> <para>hard block</para>
+        ///   <para>hard block</para> <code>soft block</code>
+        ///   <para>hard block</para> <c>inline</c>
+        /// 
+        ///   <code>soft block</code> <para>hard block</para>
+        ///   <code>soft block</code> <code>soft block</code>
+        ///   <code>soft block</code> <c>inline</c>
+        /// 
+        ///   <c>inline</c> <para>hard block</para>
+        ///   <c>inline</c> <code>soft block</code>
+        ///   <c>inline</c> <c>inline</c>
+        /// </para>
+        /// </remarks>
+        public class BlockAndInlineAdjacentBySpace
+        {
+        }
+
+        [Fact]
+        public void When_block_inlines_adjacent_by_space_then_they_are_repels_heuristically()
+        {
+            //// Arrange
+            XmlDocs.ClearCache();
+
+            //// Act
+            var summary = typeof(BlockAndInlineAdjacentBySpace).GetXmlDocsRemarks();
+
+            //// Assert
+            var expected = @"hard block
+
+hard block
+
+hard block
+
+```
+soft block
+```
+hard block
+
+`inline`
+
+```
+soft block
+```
+hard block
+
+```
+soft block
+```
+```
+soft block
+```
+```
+soft block
+```
+`inline`
+
+`inline`
+hard block
+
+`inline`
+```
+soft block
+```
+`inline` `inline`".Replace("\r", "");
+            Assert.Equal(expected, summary);
+        }
+
+        /// <remarks>
+        /// <para>
+        /// <para>hard block</para>
+        /// <para>hard block</para>
+        ///
+        /// <para>hard block</para>
+        /// <code>soft block</code>
+        /// 
+        /// <para>hard block</para>
+        /// <c>inline</c>
+        ///
+        /// 
+        /// <code>soft block</code>
+        /// <para>hard block</para>
+        /// 
+        /// <code>soft block</code>
+        /// <code>soft block</code>
+        /// 
+        /// <code>soft block</code>
+        /// <c>inline</c>
+        ///
+        /// 
+        /// <c>inline</c>
+        /// <para>hard block</para>
+        /// 
+        /// <c>inline</c>
+        /// <code>soft block</code>
+        /// 
+        /// <c>inline</c>
+        /// <c>inline</c>
+        /// </para>
+        /// </remarks>
+        public class BlockAndInlineNewlines
+        {
+        }
+
+        [Fact]
+        public void When_block_inlines_adjacent_by_newline_then_they_respects_newline_heuristically()
+        {
+            //// Arrange
+            XmlDocs.ClearCache();
+
+            //// Act
+            var summary = typeof(BlockAndInlineNewlines).GetXmlDocsRemarks();
+
+            //// Assert
+            var expected = @"hard block
+
+hard block
+
+
+hard block
+
+```
+soft block
+```
+
+hard block
+
+`inline`
+
+
+```
+soft block
+```
+hard block
+
+
+```
+soft block
+```
+```
+soft block
+```
+
+```
+soft block
+```
+`inline`
+
+
+`inline`
+hard block
+
+
+`inline`
+```
+soft block
+```
+
+`inline`
+`inline`".Replace("\r", "");
+            Assert.Equal(expected, summary);
+        }
+    }
+}

--- a/src/Namotion.Reflection/Markdown/Ast.cs
+++ b/src/Namotion.Reflection/Markdown/Ast.cs
@@ -1,0 +1,703 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Namotion.Reflection.Markdown
+{
+    internal abstract class MarkdownNode
+    {
+        internal virtual bool IsBlock => false;
+        internal virtual bool IsInline => !IsBlock;
+
+        /// <summary>
+        /// It is used when <c>IsBlock</c>
+        /// </summary>
+        internal virtual DelimiterNode DelimiterAfterBlock => DelimiterNode.NewLine;
+
+        public string Render(int indent = 0)
+        {
+            var context = new RenderContext(new StringBuilder(), indent, indent);
+            RenderInternal(context);
+            return context.ToString();
+        }
+
+        public void Render(StringBuilder builder, int indentFirstLine, int indentRest)
+        {
+            var context = new RenderContext(builder, indentFirstLine, indentRest);
+            RenderInternal(context);
+        }
+
+        /// <remarks>
+        /// General rules
+        /// <list type="number">
+        /// <item>Don't put a newline character at the end unless it is necessary.</item>
+        /// <item>
+        ///   Call <c>context.IndentForFirstLine()</c> or its equivalent inside of this function for the first line
+        ///   if this is <c>IsBlock</c> element.
+        /// </item>
+        /// </list>
+        /// </remarks>
+        internal abstract void RenderInternal(RenderContext context);
+
+        protected static void RenderIndented(RenderContext context, string value)
+        {
+            var lines = value.Split(new[] { "\r\n", "\n\r", "\n", "\r" }, StringSplitOptions.None);
+            if (lines.Length == 0)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(lines[0]))
+            {
+                context.IndentForFirstLine();
+                context.Append(lines[0]);
+            }
+            else
+            {
+                // Can omit context.IndentForFirstLine();
+                // They are dedented later anyway.
+            }
+
+            foreach (var line in lines.Skip(1))
+            {
+                context.AppendLine();
+                if (!string.IsNullOrEmpty(line))
+                    context.IndentForRest();
+                context.Append(line);
+            }
+        }
+
+        public override string ToString()
+        {
+            return Render();
+        }
+    }
+
+    internal sealed class RenderContext
+    {
+        private readonly StringBuilder _builder;
+        private readonly int _indentForFirstLine;
+        private readonly int _indentForRest;
+
+        internal RenderContext(StringBuilder builder, int indentForFirstLine, int indentForRest)
+        {
+            _builder = builder;
+            _indentForFirstLine = indentForFirstLine;
+            _indentForRest = indentForRest;
+        }
+
+        public RenderContext WithNoIndentation(int amount = 0)
+        {
+            return new RenderContext(_builder, 0, _indentForRest + amount);
+        }
+
+        public RenderContext WithIndentationForRest(int amount = 0)
+        {
+            return new RenderContext(_builder, _indentForRest + amount, _indentForRest + amount);
+        }
+
+        public void IndentForFirstLine()
+        {
+            Indent(_indentForFirstLine);
+        }
+
+        public void IndentForRest()
+        {
+            Indent(_indentForRest);
+        }
+
+        private void Indent(int indent)
+        {
+            for (var i = 0; i < indent; i++)
+            {
+                _builder.Append(' ');
+            }
+        }
+
+        public void Append(string value = null)
+        {
+            _builder.Append(value);
+        }
+
+        public void Append(char value)
+        {
+            _builder.Append(value);
+        }
+
+        public void AppendLine(string value = null)
+        {
+            _builder.Append(value);
+            _builder.Append('\n');
+        }
+
+        public override string ToString()
+        {
+            return _builder.ToString();
+        }
+    }
+
+    internal class TextNode : MarkdownNode
+    {
+        public TextNode(string value, DelimiterNode startedWith, DelimiterNode endedWith)
+        {
+            Value = value;
+            StartedWith = startedWith;
+            EndedWith = endedWith;
+        }
+
+        public string Value { get; }
+        public DelimiterNode StartedWith { get; }
+        public DelimiterNode EndedWith { get; }
+
+        internal override void RenderInternal(RenderContext context)
+        {
+            RenderIndented(context.WithNoIndentation(), Value);
+        }
+
+        public override string ToString()
+        {
+            return $"{StartedWith}{Value}{EndedWith}";
+        }
+    }
+
+    internal sealed class ParagraphNode : MarkdownNode
+    {
+        internal override bool IsBlock => true;
+        internal override DelimiterNode DelimiterAfterBlock => DelimiterNode.HardNewLine;
+
+        private readonly MarkdownNode _value;
+
+        public ParagraphNode(MarkdownNode value)
+        {
+            _value = value;
+        }
+
+        internal override void RenderInternal(RenderContext context)
+        {
+            _value.RenderInternal(context);
+        }
+    }
+
+    internal sealed class InlineHtmlNode : MarkdownNode
+    {
+        private readonly string _value;
+
+        public InlineHtmlNode(string value)
+        {
+            _value = value;
+        }
+
+        internal override void RenderInternal(RenderContext context)
+        {
+            RenderIndented(context.WithNoIndentation(), _value);
+        }
+    }
+
+    internal sealed class HtmlBlockNode : MarkdownNode
+    {
+        internal override bool IsBlock => true;
+
+        private readonly string _value;
+
+        public HtmlBlockNode(string value)
+        {
+            _value = value;
+        }
+
+        internal override void RenderInternal(RenderContext context)
+        {
+            RenderIndented(context, _value);
+        }
+    }
+
+    internal sealed class AutoLinkNode : MarkdownNode
+    {
+        private readonly string _url;
+
+        public AutoLinkNode(string url)
+        {
+            _url = url;
+        }
+
+        internal override void RenderInternal(RenderContext context)
+        {
+            context.Append('<');
+            context.Append(_url);
+            context.Append('>');
+        }
+    }
+
+    internal sealed class LinkNode : MarkdownNode
+    {
+        private readonly string _url;
+        private readonly MarkdownNode _text;
+
+        public LinkNode(MarkdownNode text, string url)
+        {
+            _text = text;
+            _url = url;
+        }
+
+        public string Title { get; set; }
+
+        internal override void RenderInternal(RenderContext context)
+        {
+            context.Append('[');
+            RenderText(context, _text.Render());
+            context.Append(']');
+
+            context.Append('(');
+            RenderUrl(context, _url);
+            if (Title != null)
+            {
+                context.Append(' ');
+                RenderTitle(context, Title);
+            }
+
+            context.Append(')');
+        }
+
+        private static void RenderText(RenderContext context, string text)
+        {
+            context.Append(text.Replace("\\", "\\\\").Replace("[", "\\[").Replace("]", "\\]"));
+        }
+
+        private static void RenderUrl(RenderContext context, string url)
+        {
+            var chars = url.ToCharArray();
+            var containsNonPrintable = chars.Any(c => char.IsWhiteSpace(c) || char.IsControl(c));
+            if (containsNonPrintable)
+            {
+                context.Append('<');
+                context.Append(url.Replace("\\", "\\\\").Replace("<", "\\>").Replace(">", "\\>"));
+                context.Append('>');
+            }
+            else
+            {
+                context.Append(url.Replace("\\", "\\\\").Replace("(", "\\(").Replace(")", "\\)"));
+            }
+        }
+
+        private static void RenderTitle(RenderContext context, string title)
+        {
+            // title can contain newlines. So use RenderIndented
+            var chars = title.ToCharArray();
+            var singleQuotes = chars.Count(c => c == '\'');
+            var doubleQuotes = chars.Count(c => c == '\"');
+            // We can use "()" for quoting, but we use only single/double quotes for the sake of simplicity.
+            if (singleQuotes < doubleQuotes)
+            {
+                context.Append('\'');
+                RenderIndented(context.WithNoIndentation(), title.Replace("'", "\\'"));
+                context.Append('\'');
+            }
+            else
+            {
+                context.Append('"');
+                RenderIndented(context.WithNoIndentation(), title.Replace("\"", "\\\""));
+                context.Append('"');
+            }
+        }
+    }
+
+    internal sealed class CodeNode : MarkdownNode
+    {
+        private readonly string _value;
+
+        public CodeNode(string value)
+        {
+            _value = value;
+        }
+
+        internal override void RenderInternal(RenderContext context)
+        {
+            var quote = GetQuote(_value);
+            var pad = _value.StartsWith("`") || _value.EndsWith("`");
+            context.Append(quote);
+            if (pad)
+            {
+                context.Append(' ');
+            }
+
+            RenderIndented(context.WithNoIndentation(), _value);
+            if (pad)
+            {
+                context.Append(' ');
+            }
+
+            context.Append(quote);
+        }
+
+        /// <summary>
+        /// Find shortest code span quote.
+        /// According to the CommonMark spec, code span ends with a backtick string of equal length.
+        /// So it finds a shortest backticks that does not appears in the code block
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// GetQuote("` `` ````") == "```"
+        /// </code>
+        /// <code>
+        /// GetQuote("`` ````") == "`"
+        /// </code>
+        /// </example>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private static string GetQuote(string value)
+        {
+            var quoteLengthSet = new SortedSet<int>();
+
+            foreach (Match quote in Regex.Matches(value, "`+"))
+            {
+                quoteLengthSet.Add(quote.Length);
+            }
+
+            if (quoteLengthSet.Count == 0)
+            {
+                return "`";
+            }
+
+            var quoteLengths = quoteLengthSet.ToList();
+            var selectedLength = 1;
+            foreach (var quoteLength in quoteLengths)
+            {
+                if (quoteLength != selectedLength)
+                {
+                    break;
+                }
+
+                selectedLength++;
+            }
+
+            return string.Join("", Enumerable.Repeat("`", selectedLength));
+        }
+    }
+
+    internal sealed class CodeBlockNode : MarkdownNode
+    {
+        internal override bool IsBlock => true;
+
+        private readonly string _value;
+
+        public CodeBlockNode(string value)
+        {
+            _value = value;
+        }
+
+        public string Info { get; set; }
+
+        internal override void RenderInternal(RenderContext context)
+        {
+            var fence = GetFence(_value);
+            context.IndentForFirstLine();
+            context.Append(fence);
+            if (Info != null)
+            {
+                context.Append(Info);
+            }
+
+            context.AppendLine();
+
+            if (!string.IsNullOrEmpty(_value))
+            {
+                RenderIndented(context.WithIndentationForRest(), _value);
+                context.AppendLine();
+            }
+
+            context.IndentForRest();
+            context.Append(fence);
+        }
+
+        /// <summary>
+        /// Find shortest code block fence.
+        /// According to the CommonMark spec, code block ends with a fence of equal length.
+        /// So it finds a shortest fence that does not appears in the code block
+        /// </summary>
+        /// <example>
+        /// </example>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private static string GetFence(string value)
+        {
+            var fenceLengthSet = new SortedSet<int>();
+            var lines = value.Split(
+                new[] { "\r\n", "\n\r", "\n", "\r" },
+                StringSplitOptions.None);
+            foreach (var line in lines)
+            {
+                var trimmed = line.Trim(' ').ToCharArray();
+                if (trimmed.Length < 3 || trimmed.Any(x => x != '`')) // Not a closing fence
+                {
+                    continue;
+                }
+
+                var spaces = line.Length - line.TrimStart(' ').Length;
+                if (spaces >= 4) // It indented too much. It is not a fence.
+                {
+                    continue;
+                }
+
+                fenceLengthSet.Add(trimmed.Length);
+            }
+
+            if (fenceLengthSet.Count == 0)
+            {
+                return "```";
+            }
+
+            var fenceLengths = fenceLengthSet.ToList();
+            var selectedLength = 3;
+            foreach (var fenceLength in fenceLengths)
+            {
+                if (fenceLength != selectedLength)
+                {
+                    break;
+                }
+
+                selectedLength++;
+            }
+
+            return string.Join("", Enumerable.Repeat("`", selectedLength));
+        }
+    }
+
+    internal class NodeCollection<T> : MarkdownNode, IEnumerable<T>
+        where T : MarkdownNode
+    {
+        protected readonly IList<T> nodes;
+
+        public NodeCollection()
+        {
+            nodes = new List<T>();
+        }
+
+        protected NodeCollection(IEnumerable<T> nodes)
+        {
+            this.nodes = nodes.ToList();
+        }
+
+        internal override void RenderInternal(RenderContext context)
+        {
+            DelimiterNode lastDelimiterNode = null;
+            if (nodes.Count > 0)
+            {
+                nodes[0].RenderInternal(context);
+                lastDelimiterNode = nodes[0] as DelimiterNode;
+            }
+
+            foreach (var node in nodes.Skip(1))
+            {
+                if (
+                    (Equals(lastDelimiterNode, DelimiterNode.NewLine) ||
+                     Equals(lastDelimiterNode, DelimiterNode.HardNewLine)) &&
+                    node.IsInline)
+                {
+                    // HACK: compensate indentation for inline block right after the newline.
+                    context.IndentForRest();
+                    node.RenderInternal(context.WithNoIndentation());
+                }
+                else if (Equals(lastDelimiterNode, DelimiterNode.None) ||
+                         Equals(lastDelimiterNode, DelimiterNode.Space) ||
+                         node is DelimiterNode
+                )
+                {
+                    node.RenderInternal(context.WithNoIndentation());
+                }
+                else // IsBlock || Newline || HardNewline
+                {
+                    node.RenderInternal(context.WithIndentationForRest());
+                }
+
+                lastDelimiterNode = node as DelimiterNode;
+            }
+        }
+
+        public void Add(T node)
+        {
+            nodes.Add(node);
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return nodes.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
+    // pseudo node for syntactic decoration 
+    internal class DelimiterNode : MarkdownNode
+    {
+        public static readonly DelimiterNode None = new DelimiterNode(null);
+        public static readonly DelimiterNode Space = new DelimiterNode(" ");
+        public static readonly DelimiterNode NewLine = new DelimiterNode("\n");
+        public static readonly DelimiterNode HardNewLine = new DelimiterNode("\n\n");
+
+        internal override bool IsBlock => false;
+
+        private readonly string _delimiter;
+
+        private DelimiterNode(string delimiter)
+        {
+            _delimiter = delimiter;
+        }
+
+        internal override void RenderInternal(RenderContext context)
+        {
+            context.Append(_delimiter);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is DelimiterNode delimiterNode && _delimiter == delimiterNode._delimiter;
+        }
+
+        public override int GetHashCode()
+        {
+            return _delimiter.GetHashCode();
+        }
+    }
+
+    internal abstract class ListNode : NodeCollection<ListItemNode>
+    {
+        internal override bool IsBlock => true;
+
+        internal override DelimiterNode DelimiterAfterBlock => DelimiterNode.HardNewLine;
+
+        public abstract void Add(params MarkdownNode[] nodes);
+
+        internal override void RenderInternal(RenderContext context)
+        {
+            if (nodes.Count > 0)
+            {
+                nodes[0].RenderInternal(context);
+            }
+
+            foreach (var node in nodes.Skip(1))
+            {
+                context.AppendLine();
+                node.RenderInternal(context.WithIndentationForRest());
+            }
+        }
+    }
+
+    internal sealed class BulletListNode : ListNode
+    {
+        public override void Add(params MarkdownNode[] nodes)
+        {
+            var node = new ListItemNode("* ", nodes);
+            this.nodes.Add(node);
+        }
+    }
+
+    internal sealed class NumberedListNode : ListNode
+    {
+        public override void Add(params MarkdownNode[] nodes)
+        {
+            var label = this.nodes.Count + 1;
+            var node = new ListItemNode($"{label}. ", nodes);
+            this.nodes.Add(node);
+        }
+    }
+
+    internal sealed class ListItemNode : NodeCollection<MarkdownNode>
+    {
+        private readonly string _marker;
+
+        public ListItemNode(string marker, params MarkdownNode[] nodes)
+            : base(nodes)
+        {
+            _marker = marker;
+        }
+
+        internal override void RenderInternal(RenderContext context)
+        {
+            context.IndentForFirstLine();
+            context.Append(_marker);
+            if (nodes.Count > 0)
+            {
+                nodes[0].RenderInternal(context.WithNoIndentation(_marker.Length));
+            }
+
+            foreach (var value in nodes.Skip(1))
+            {
+                context.AppendLine();
+                value.RenderInternal(context.WithIndentationForRest(_marker.Length));
+            }
+        }
+    }
+
+    internal sealed class TableNode : MarkdownNode
+    {
+        internal override bool IsBlock => true;
+        internal override DelimiterNode DelimiterAfterBlock => DelimiterNode.HardNewLine;
+
+        private readonly List<string> _labels = new List<string>();
+        private readonly Dictionary<string, string> _headers = new Dictionary<string, string>();
+
+        private readonly List<Dictionary<string, NodeCollection<MarkdownNode>>> _rows =
+            new List<Dictionary<string, NodeCollection<MarkdownNode>>>();
+
+        internal override void RenderInternal(RenderContext context)
+        {
+            if (_labels.Count == 0)
+                return;
+
+            context.IndentForFirstLine();
+            context.Append("| ");
+            context.Append(_headers[_labels[0]]);
+            foreach (var label in _labels.Skip(1))
+            {
+                context.Append(" | ");
+                context.Append(_headers[label]);
+            }
+
+            context.Append(" |");
+
+            context.AppendLine();
+            context.IndentForRest();
+            context.Append('|');
+            // Can't easily decide width of non-latin strings (e.g. CJK, emoji, NJW, etc.)
+            context.Append(string.Join("|", Enumerable.Repeat("---", _labels.Count)));
+            context.Append('|');
+
+            foreach (var row in _rows)
+            {
+                context.AppendLine();
+                context.IndentForRest();
+                context.Append("| ");
+                row[_labels[0]].RenderInternal(context.WithNoIndentation());
+                foreach (var label in _labels.Skip(1))
+                {
+                    context.Append(" | ");
+                    row[label].RenderInternal(context.WithNoIndentation());
+                }
+
+                context.Append(" |");
+            }
+        }
+
+        public void AddHeader(string label, string header)
+        {
+            if (!_labels.Contains(label))
+            {
+                _labels.Add(label);
+            }
+
+            _headers.Add(label, header);
+        }
+
+        public IDictionary<string, NodeCollection<MarkdownNode>> CreateRow()
+        {
+            var row = new Dictionary<string, NodeCollection<MarkdownNode>>();
+            _rows.Add(row);
+            return row;
+        }
+    }
+}

--- a/src/Namotion.Reflection/Markdown/XmlTransform.cs
+++ b/src/Namotion.Reflection/Markdown/XmlTransform.cs
@@ -1,0 +1,459 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Namotion.Reflection.Markdown
+{
+    internal static class XmlTransform
+    {
+        /// <summary>Converts the given XML documentation <see cref="XElement"/> to Markdown.</summary>
+        /// <param name="element">The XML element.</param>
+        /// <returns>The Markdown</returns>
+        public static string ToMarkdown(XElement element)
+        {
+            // ToMarkdown -> ToMarkdownNode  <-> ToMarkdownNodeCollection
+            // ^- top level  ^- inside of XML ^- mutual recursion
+            if (element == null)
+            {
+                return string.Empty;
+            }
+
+            var builder = new StringBuilder();
+            var lastIndent = 0;
+            foreach (var node in element.Nodes())
+            {
+                if (node is XElement e && ToMarkdownNode(e) is var markdownNode && markdownNode != null)
+                {
+                    markdownNode.Render(builder, 0, lastIndent);
+                }
+                else
+                {
+                    // Formats of top level texts are preserved
+                    var text = node.ToString();
+                    var lastNewline = text.LastIndexOfAny(new[] { '\n', '\r' });
+                    lastIndent = lastNewline == -1 ? 0 : text.Length - lastNewline - 1;
+                    builder.Append(node);
+                }
+            }
+
+            return DedentFinalResult(builder.ToString());
+        }
+
+        private static NodeCollection<MarkdownNode> ToMarkdownNodeCollection(IEnumerable<XNode> nodes)
+        {
+            var collected = new List<MarkdownNode>();
+            foreach (var node in nodes)
+            {
+                if (node is XElement e && ToMarkdownNode(e) is var markdownNode && markdownNode != null)
+                {
+                    collected.Add(markdownNode);
+                }
+                else if (node is XText textNode)
+                {
+                    collected.Add(ConvertTextNode(textNode));
+                }
+
+                // Skip XComment, XDocumentType, XProcessingInstruction, XDocument
+            }
+
+            return CreateDeliminatedNodeCollection(collected);
+        }
+
+        /// They are defined in <a href="https://spec.commonmark.org/0.29/#html-blocks">CommonMark spec</a>
+        private static readonly HashSet<string> htmlBlocks =
+            new HashSet<string>
+            {
+                "address", "article", "aside", "base", "basefont", "blockquote", "body", "caption", "center", "col", 
+                "colgroup", "dd", "details", "dialog", "dir", "div", "dl", "dt", "fieldset", "figcaption", "figure", 
+                "footer", "form", "frame", "frameset", "h1", "h2", "h3", "h4", "h5", "h6", "head", "header", "hr", 
+                "html", "iframe", "legend", "li", "link", "main", "menu", "menuitem", "nav", "noframes", "ol", 
+                "optgroup", "option", "p", "param", "section", "source", "summary", "table", "tbody", "td", "tfoot", 
+                "th", "thead", "title", "tr", "track", "ul"
+            };
+
+        private static MarkdownNode ToMarkdownNode(XElement element)
+        {
+            if (element.Name == "see")
+            {
+                var langword = element.Attribute("langword");
+                if (langword != null)
+                {
+                    return new CodeNode(langword.Value);
+                }
+
+                var cref = element.Attribute("cref");
+                if (cref != null)
+                {
+                    var crefValue = cref.Value.Trim('!', ':').Trim().Split('.').Last();
+                    return new CodeNode(crefValue);
+                }
+
+                var href = element.Attribute("href")?.Value ?? string.Empty;
+
+                return new AutoLinkNode(href);
+            }
+
+            if (element.Name == "a")
+            {
+                // assume all inline
+                var text = ToMarkdownNodeCollection(element.Nodes());
+                var hrefAttribute = element.Attribute("href");
+                var href = hrefAttribute != null ? hrefAttribute.Value : string.Empty;
+                return new LinkNode(text, href) { Title = element.Attribute("title")?.Value };
+            }
+
+            if (element.Name == "c")
+            {
+                return new CodeNode(DedentElement(element));
+            }
+
+            if (element.Name == "code")
+            {
+                return new CodeBlockNode(DedentElement(element))
+                {
+                    Info = element.Attribute("lang")?.Value // Non standard, but useful extension
+                };
+            }
+
+            if (element.Name == "paramref" || element.Name == "typeparamref")
+            {
+                var name = element.Attribute("name")?.Value ?? string.Empty;
+                return new CodeNode(name);
+            }
+
+            if (element.Name == "para")
+            {
+                return new ParagraphNode(ToMarkdownNodeCollection(element.Nodes()));
+            }
+
+            if (element.Name == "list")
+            {
+                var type = element.Attribute("type")?.Value;
+                var items = element.Nodes().OfType<XElement>().Where(x => x.Name == "item");
+                if (type == "bullet" || type == "number")
+                {
+                    var node = type == "bullet" ? (ListNode) new BulletListNode() : new NumberedListNode();
+                    foreach (var item in items)
+                    {
+                        // JetBrains Rider prefers <description> element.
+                        var description = item.Nodes().OfType<XElement>().FirstOrDefault(x => x.Name == "description");
+                        node.Add(ToMarkdownNodeCollection(description != null ? description.Nodes() : item.Nodes()));
+                    }
+
+                    return node;
+                }
+
+                if (type == "table")
+                {
+                    var node = new TableNode();
+
+                    var listHeader = element.Nodes().OfType<XElement>().FirstOrDefault(x => x.Name == "listheader");
+                    if (listHeader != null)
+                    {
+                        foreach (var headerElement in listHeader.Nodes().OfType<XElement>())
+                        {
+                            node.AddHeader(headerElement.Name.LocalName, DedentElement(headerElement));
+                        }
+                    }
+
+                    foreach (var item in items)
+                    {
+                        var row = node.CreateRow();
+                        foreach (var itemElement in item.Nodes().OfType<XElement>())
+                        {
+                            row[itemElement.Name.LocalName] = ToMarkdownNodeCollection(itemElement.Nodes());
+                        }
+                    }
+
+                    return node;
+                }
+            }
+
+            if (htmlBlocks.Contains(element.Name.LocalName))
+            {
+                return new HtmlBlockNode(DedentHtmlElement(element));
+            }
+
+            return new InlineHtmlNode(DedentHtmlElement(element));
+        }
+
+        private static readonly string[] Newlines = { "\r\n", "\n\r", "\n", "\r" };
+
+        private static string DedentElement(XElement element)
+        {
+            // e.g.
+            //  v-- LinePosition. 1-based.
+            // <code>
+            //           some
+            //        irregular
+            //            indentation
+            //    </code>
+            //        ^- adjust to here
+            var lines = SplitLine(element.Value, true);
+            var indent = GetIndentation(((IXmlLineInfo) element).LinePosition - 2, lines);
+            return Dedent(lines, line => TrimWhitespacesAtMost(indent, line));
+        }
+
+        private static string DedentHtmlElement(XElement element)
+        {
+            // e.g.
+            //  v-- LinePosition. 1-based.
+            // <h1>
+            //           some
+            //            header
+            //       </h1>
+            //       ^- adjust to here
+            var lines = SplitLine(element.ToString(), true);
+            var indent = GetIndentation(((IXmlLineInfo) element).LinePosition - 2, lines);
+
+            var builder = new StringBuilder();
+            if (lines.Count > 0)
+            {
+                builder.Append(lines[0]); // Append without dedent since XNode.ToString() doesn't indent first line.
+            }
+
+            foreach (var line in lines.Skip(1))
+            {
+                builder.Append('\n');
+                builder.Append(line.Substring(indent));
+            }
+
+            return builder.ToString();
+        }
+
+        private static string DedentFinalResult(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            // e.g.
+            //      some
+            //    irregular
+            //       indentation
+            //    ^- adjust to here
+            var lines = SplitLine(value, true);
+            var indent = GetIndentation(1, lines);
+            return Dedent(lines, line => TrimWhitespacesAtMost(indent, line));
+        }
+
+        private static string Dedent(IList<string> lines, Func<string, string> dedent)
+        {
+            var builder = new StringBuilder();
+            if (lines.Count > 0)
+            {
+                builder.Append(dedent(lines[0]));
+            }
+
+            foreach (var line in lines.Skip(1))
+            {
+                builder.Append('\n');
+                builder.Append(dedent(line));
+            }
+
+            return builder.ToString();
+        }
+
+        private static List<string> SplitLine(string value, bool trimBothEmptyLines)
+        {
+            var lines = value.Split(Newlines, StringSplitOptions.None);
+            var skip = 0;
+            var take = lines.Length;
+
+            if (trimBothEmptyLines)
+            {
+                if (string.IsNullOrWhiteSpace(lines.First()))
+                {
+                    skip++;
+                    take--;
+                }
+
+                if (string.IsNullOrWhiteSpace(lines.Last()))
+                {
+                    take--;
+                }
+            }
+
+            return lines.Skip(skip).Take(take).ToList();
+        }
+
+        private static int GetIndentation(int filterMinimumIndent, IList<string> lines)
+        {
+            if (lines.Count == 0)
+            {
+                return 0;
+            }
+
+            var indent = int.MaxValue;
+            foreach (var line in lines)
+            {
+                var whitespaces = Regex.Match(line, "^\\s*").Length;
+                if (whitespaces < filterMinimumIndent)
+                {
+                    continue;
+                }
+
+                indent = Math.Min(indent, whitespaces);
+            }
+
+            return indent;
+        }
+
+        private static string TrimWhitespacesAtMost(int count, string text)
+        {
+            var nonWsIndex = 0;
+            while (nonWsIndex < text.Length && char.IsWhiteSpace(text[nonWsIndex]) && nonWsIndex < count)
+            {
+                nonWsIndex++;
+            }
+
+            return text.Substring(nonWsIndex);
+        }
+
+        private static MarkdownNode ConvertTextNode(XText textNode)
+        {
+            var lines = textNode.Value.Split(new[] { "\r\n", "\n\r", "\n", "\r" }, StringSplitOptions.None);
+            // Assert(lines.Length > 0)
+            if (lines.All(string.IsNullOrWhiteSpace))
+            {
+                switch (lines.Length)
+                {
+                    case 1 when lines[0].Length == 0:
+                        return DelimiterNode.None; // custom delimiter
+                    case 1:
+                        return DelimiterNode.Space; // custom delimiter
+                    case 2:
+                        return DelimiterNode.NewLine; // custom delimiter
+                    case 3:
+                        return new TextNode(
+                            string.Join("", Enumerable.Repeat("\n", lines.Length - 3)),
+                            DelimiterNode.NewLine,
+                            DelimiterNode.NewLine);
+                }
+            }
+
+            var skip = 0;
+            var take = lines.Length;
+
+            var startedWith = DelimiterNode.None;
+            if (string.IsNullOrWhiteSpace(lines.First()))
+            {
+                startedWith = DelimiterNode.NewLine;
+                skip++;
+                take--;
+            }
+            else if (lines.First().StartsWith(" ") || lines.First().StartsWith("\t"))
+            {
+                startedWith = DelimiterNode.Space;
+            }
+
+            var endedWith = DelimiterNode.None;
+            if (string.IsNullOrWhiteSpace(lines.Last()))
+            {
+                endedWith = DelimiterNode.NewLine;
+                take--;
+            }
+            else if (lines.Last().EndsWith(" ") || lines.Last().EndsWith("\t"))
+            {
+                endedWith = DelimiterNode.Space;
+            }
+
+            var joined = string.Join("\n", lines.Skip(skip).Take(take).Select(line => line.Trim()));
+            return new TextNode(joined, startedWith, endedWith);
+        }
+
+        /// <summary>
+        /// Create <see cref="NodeCollection{T}"/> with delimiter heuristics.
+        /// </summary>
+        private static NodeCollection<MarkdownNode> CreateDeliminatedNodeCollection(List<MarkdownNode> collected)
+        {
+            var result = new NodeCollection<MarkdownNode>();
+            var end = Math.Max(collected.Count - 1, 0);
+            MarkdownNode lastInserted = null;
+            for (var i = 0; i < end; i++)
+            {
+                var left = collected[i];
+                var right = collected[i + 1];
+
+                // Trim the first empty line
+                if (i == 0 &&
+                    (left is TextNode first && string.IsNullOrWhiteSpace(first.Value) ||
+                     left is DelimiterNode))
+                {
+                    continue;
+                }
+
+                // Trim the last empty line
+                if (i + 1 == end &&
+                    (right is TextNode last && string.IsNullOrWhiteSpace(last.Value) ||
+                     right is DelimiterNode))
+                {
+                    result.Add(left);
+                    return result;
+                }
+
+                // Skip subsequent custom delimiters
+                if (lastInserted is DelimiterNode && left is DelimiterNode)
+                {
+                    continue;
+                }
+
+                if (left.IsInline && right.IsInline)
+                {
+                    if (left is TextNode leftText)
+                    {
+                        result.Add(left);
+                        result.Add(leftText.EndedWith);
+                    }
+                    else if (right is TextNode rightText)
+                    {
+                        result.Add(left);
+                        result.Add(rightText.StartedWith);
+                    }
+                    else if (right is DelimiterNode)
+                    {
+                        result.Add(left);
+                        // the delimiter will be decided next iteration
+                    }
+                    else
+                    {
+                        result.Add(left);
+                        result.Add(DelimiterNode.None);
+                    }
+                }
+                else if (left.IsInline && right.IsBlock)
+                {
+                    // Skip custom delimiter between inline and block
+                    if (!(lastInserted?.IsInline == true && left is DelimiterNode))
+                    {
+                        result.Add(left);
+                    }
+
+                    // Insert a newline at the boundary between inline-block unconditionally.
+                    result.Add(DelimiterNode.NewLine);
+                }
+                else if (left.IsBlock)
+                {
+                    result.Add(left);
+                    // Insert a newline after a block node. Each block node has its taste of newline.
+                    result.Add(left.DelimiterAfterBlock);
+                }
+                // Since IsBlock != IsInline, all cases are covered
+
+                lastInserted = result.Last();
+            }
+
+            if (collected.LastOrDefault() != null)
+            {
+                result.Add(collected.Last());
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Implementation for https://github.com/RicoSuter/NJsonSchema/issues/1171

I've tried to generate Markdown that looks pleasing and tried to respect the format of inputs such as newlines. You can even mix Markdown-based documents and XML-based documents.

## Caveats

### Tags/attributes that are not listed in the recommended tags.
C# programming guide lists a set of recommended tags and their attributes.
https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/xmldoc/recommended-tags-for-documentation-comments
However, they are 'recommendation'. Also, already existing implementation uses non-recommended tags and attributes such as `response`, `href`, `langword`.
So I've added some more.
1. `lang` attribute for `code` tags
   Markdown code block can annotate additional info of code block. So I've added them.
2. `a` tags and other HTML tags.
   Markdown allows embedding HTML tags. I've specialized `a` it to generate a link, and block elements according to the CommonMark spec.

### Simplication
I can't decide the width of character easily without additional dependencies (e.g. CJK, normalization, emojis, ZWJs, etc). So I've simplified table implementation. They look ugly but the diff will be simpler later.

### Some inherent limitations of Markdown
XML such as
```
This is an example of <c>invalid
markdown ` ``
</c>
generation
```
will be converted to
``````
This is an example of ```invalid
markdown ` ``
```
generation
``````
and it'll be rendered as
![image](https://user-images.githubusercontent.com/5465658/81636668-5f466e80-944f-11ea-98a2-6d8b47561940.png)

This is not an expected result. However, there is no way to escape this due to the limitation of Markdown.

### misc
A table is a part of Github Flavored Markdown which is an extension of CommonMark, but not a part of CommonMark. OpenAPI 2.0 requires GFM but 3.0 requires CommonMark at minimum.

I've annotated `HACK` comments wherever I've attempted to make output pleasant.