### PR TITLE
Support get xml element name for multiple or nested generic parameter type 

### DIFF
--- a/src/Namotion.Reflection.Tests/XmlDocsExtensionsTests.cs
+++ b/src/Namotion.Reflection.Tests/XmlDocsExtensionsTests.cs
@@ -385,6 +385,22 @@ namespace Namotion.Reflection.Tests
             }
 
             /// <summary>
+            /// MultiGenericParameter
+            /// </summary>
+            public IDictionary<string, string> MultiGenericParameter(IDictionary<string, string> input)
+            {
+                throw new NotImplementedException();
+            }
+            
+            /// <summary>
+            /// NestedGenericParameter
+            /// </summary>
+            public IDictionary<string, IDictionary<string, IDictionary<string, string>>> NestedGenericParameter(IDictionary<string, IDictionary<string, IDictionary<string, string>>> input)
+            {
+                throw new NotImplementedException();
+            }
+            
+            /// <summary>
             /// SingleAsync
             /// </summary>
             public Task<T> SingleAsync(T input)
@@ -399,6 +415,23 @@ namespace Namotion.Reflection.Tests
             {
                 throw new NotImplementedException();
             }
+            
+            /// <summary>
+            /// MultiGenericParameterAsync
+            /// </summary>
+            public Task<IDictionary<string, string>> MultiGenericParameterAsync(IDictionary<string, string> input)
+            {
+                throw new NotImplementedException();
+            }
+
+            /// <summary>
+            /// NestedGenericParameterAsync
+            /// </summary>
+            public Task<IDictionary<string, IDictionary<string, IDictionary<string, string>>>> NestedGenericParameterAsync(IDictionary<string, IDictionary<string, IDictionary<string, string>>> input)
+            {
+                throw new NotImplementedException();
+            }
+
         }
 
         public class InheritedGenericClass2 : BaseGenericClass<string>
@@ -414,14 +447,22 @@ namespace Namotion.Reflection.Tests
             //// Act
             var singleSummary = typeof(InheritedGenericClass2).GetMethod(nameof(InheritedGenericClass2.Single)).GetXmlDocsSummary();
             var multiSummary = typeof(InheritedGenericClass2).GetMethod(nameof(InheritedGenericClass2.Multi)).GetXmlDocsSummary();
+            var multiGenericParameterSummary = typeof(InheritedGenericClass2).GetMethod(nameof(InheritedGenericClass2.MultiGenericParameter)).GetXmlDocsSummary();
+            var nestedGenericParameterSummary = typeof(InheritedGenericClass2).GetMethod(nameof(InheritedGenericClass2.NestedGenericParameter)).GetXmlDocsSummary();
             var singleAsyncSummary = typeof(InheritedGenericClass2).GetMethod(nameof(InheritedGenericClass2.SingleAsync)).GetXmlDocsSummary();
             var multiAsyncSummary = typeof(InheritedGenericClass2).GetMethod(nameof(InheritedGenericClass2.MultiAsync)).GetXmlDocsSummary();
+            var multiGenericParameterAsyncSummary = typeof(InheritedGenericClass2).GetMethod(nameof(InheritedGenericClass2.MultiGenericParameterAsync)).GetXmlDocsSummary();
+            var nestedGenericParameterAsyncSummary = typeof(InheritedGenericClass2).GetMethod(nameof(InheritedGenericClass2.NestedGenericParameterAsync)).GetXmlDocsSummary();
 
             //// Assert
             Assert.Equal("Single", singleSummary);
             Assert.Equal("Multi", multiSummary);
+            Assert.Equal("MultiGenericParameter", multiGenericParameterSummary);
+            Assert.Equal("NestedGenericParameter", nestedGenericParameterSummary);
             Assert.Equal("SingleAsync", singleAsyncSummary);
             Assert.Equal("MultiAsync", multiAsyncSummary);
+            Assert.Equal("MultiGenericParameterAsync", multiGenericParameterAsyncSummary);
+            Assert.Equal("NestedGenericParameterAsync", nestedGenericParameterAsyncSummary);
         }
 
         public class BusinessProcessSearchResult : SearchBehaviorBaseResult<BusinessProcess>

--- a/src/Namotion.Reflection/Namotion.Reflection.csproj
+++ b/src/Namotion.Reflection/Namotion.Reflection.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;net40;net45</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../Namotion.Reflection.snk</AssemblyOriginatorKeyFile>

--- a/src/Namotion.Reflection/Namotion.Reflection.csproj
+++ b/src/Namotion.Reflection/Namotion.Reflection.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netstandard2.0;net40;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../Namotion.Reflection.snk</AssemblyOriginatorKeyFile>

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -542,8 +542,8 @@ namespace Namotion.Reflection
             string memberName;
             string memberTypeName;
 
-            if (member is MemberInfo memberInfo && 
-                memberInfo.DeclaringType != null && 
+            if (member is MemberInfo memberInfo &&
+                memberInfo.DeclaringType != null &&
                 memberInfo.DeclaringType.GetTypeInfo().IsGenericType)
             {
                 // Resolve member with generic arguments (Ts instead of actual types)

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -608,6 +608,7 @@ namespace Namotion.Reflection
                     var paramTypesList = string.Join(",", parameters
                         .Select(x => Regex
                             .Replace(x, "(`[0-9]+)|(, .*?PublicKeyToken=[0-9a-z]*)", string.Empty)
+                            .Replace("],[", ",")
                             .Replace("||", "`")
                             .Replace("[[", "{")
                             .Replace("]]", "}"))


### PR DESCRIPTION
Hello!

When parameter type of method have multiple generic parameter, "],[" should be replaced with "," to make correctly.

## Before
```
M:Namotion.Reflection.Tests.XmlDocsExtensionsTests.BaseGenericClass`1.MultiGenericParameter(System.Collections.Generic.IDictionary{System.String],[System.String})
```

## Should be
```
M:Namotion.Reflection.Tests.XmlDocsExtensionsTests.BaseGenericClass`1.MultiGenericParameter(System.Collections.Generic.IDictionary{System.String,System.String})
```

I found this bug when I create open api page for like `ActionMethod([FromQuery] IDictionary<T, T> queries`.

Thank you. :)