### PR TITLE
Support for constructor parameters (GetContextualParameter)

### DIFF
--- a/src/Namotion.Reflection.Tests.FullAssembly/FullAssemblyTestAction.cs
+++ b/src/Namotion.Reflection.Tests.FullAssembly/FullAssemblyTestAction.cs
@@ -4,6 +4,8 @@ namespace Namotion.Reflection.Tests.FullAssembly
 {
     public class FullAssemblyTestAction
     {
+        public FullAssemblyTestAction(string p1, string? p2, int p3, int? p4, Action p5, Action? p6, Tuple<string, string?, int, int?, Action, Action?>? t) { }
+
         public Tuple<string, string?, int, int?, Action, Action?> Method(string p1, string? p2, int p3, int? p4, Action p5, Action? p6)
         {
             return null;

--- a/src/Namotion.Reflection.Tests/NullabilityTests.cs
+++ b/src/Namotion.Reflection.Tests/NullabilityTests.cs
@@ -327,5 +327,28 @@ namespace Namotion.Reflection.Tests
             Assert.Equal(Nullability.NotNullable, drived.BaseType.GenericArguments[3].Nullability);
             Assert.Equal(Nullability.Nullable, drived.BaseType.GenericArguments[4].Nullability);
         }
+
+        [Fact]
+        public void ConstructorParameters() {
+
+            var constructors = typeof(FullAssemblyTestAction).GetConstructors();
+
+            Assert.Single(constructors);
+            var constructor = constructors[0];
+
+            // verify: public FullAssemblyTestAction(string p1, string? p2, int p3, int? p4, Action p5, Action? p6, Tuple<string, string?, int, int?, Action, Action?>? t) { }
+            var paramInfos = constructor.GetParameters();
+            Assert.Equal(7, paramInfos.Length);
+
+            var paramContexts = paramInfos.Select(p => p.ToContextualParameter()).ToArray();
+
+            Assert.Equal(Nullability.NotNullable, paramContexts[0].Nullability);
+            Assert.Equal(Nullability.Nullable, paramContexts[1].Nullability);
+            Assert.Equal(Nullability.NotNullable, paramContexts[2].Nullability);
+            Assert.Equal(Nullability.Nullable, paramContexts[3].Nullability);
+            Assert.Equal(Nullability.NotNullable, paramContexts[4].Nullability);
+            Assert.Equal(Nullability.Nullable, paramContexts[5].Nullability);
+            Assert.Equal(Nullability.Nullable, paramContexts[6].Nullability);
+        }
     }
 }

--- a/src/Namotion.Reflection/Context/ContextualTypeExtensions.cs
+++ b/src/Namotion.Reflection/Context/ContextualTypeExtensions.cs
@@ -48,11 +48,11 @@ namespace Namotion.Reflection
         }
 
         /// <summary>
-        /// Gets an array of <see cref="ContextualParameterInfo"/> for the given <see cref="MethodInfo"/> instance.
+        /// Gets an array of <see cref="ContextualParameterInfo"/> for the given <see cref="MethodBase"/> instance.
         /// </summary>
         /// <param name="method">The method.</param>
         /// <returns>The runtime properties.</returns>
-        public static ContextualParameterInfo[] GetContextualParameters(this MethodInfo method)
+        public static ContextualParameterInfo[] GetContextualParameters(this MethodBase method)
         {
             var key = "Parameters:" + method.Name + ":" + method.DeclaringType.FullName;
 


### PR DESCRIPTION
This expands support for GetContextualParameter to support ConstructorInfo, so contextual information for constructor parameters can be retrieved.