### PR TITLE
add project URL to csproj file

### DIFF
--- a/src/Namotion.Reflection.Cecil/Namotion.Reflection.Cecil.csproj
+++ b/src/Namotion.Reflection.Cecil/Namotion.Reflection.Cecil.csproj
@@ -11,6 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/RicoSuter/Namotion.Reflection/master/assets/NuGetIcon.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>.NET library with advanced reflection APIs like XML documentation reading, Null Reference Types (C# 8) reflection and string based type checks.</Description>
+    <PackageProjectUrl>https://github.com/RicoSuter/Namotion.Reflection</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.10.3" />

--- a/src/Namotion.Reflection.Cecil/Namotion.Reflection.Cecil.csproj
+++ b/src/Namotion.Reflection.Cecil/Namotion.Reflection.Cecil.csproj
@@ -9,7 +9,7 @@
     <Version>1.0.18</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageIconUrl>https://raw.githubusercontent.com/RicoSuter/Namotion.Reflection/master/assets/NuGetIcon.png</PackageIconUrl>
-    <PackageLicenseUrl>https://github.com/RicoSuter/Namotion.Reflection/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>.NET library with advanced reflection APIs like XML documentation reading, Null Reference Types (C# 8) reflection and string based type checks.</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Namotion.Reflection/Namotion.Reflection.csproj
+++ b/src/Namotion.Reflection/Namotion.Reflection.csproj
@@ -11,7 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/RicoSuter/Namotion.Reflection/master/assets/NuGetIcon.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>.NET library with advanced reflection APIs like XML documentation reading, Null Reference Types (C# 8) reflection and string based type checks.</Description>
-    <projectUrl>https://github.com/RicoSuter/Namotion.Reflection</projectUrl>
+    <PackageProjectUrl>https://github.com/RicoSuter/Namotion.Reflection</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />

--- a/src/Namotion.Reflection/Namotion.Reflection.csproj
+++ b/src/Namotion.Reflection/Namotion.Reflection.csproj
@@ -11,6 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/RicoSuter/Namotion.Reflection/master/assets/NuGetIcon.png</PackageIconUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>.NET library with advanced reflection APIs like XML documentation reading, Null Reference Types (C# 8) reflection and string based type checks.</Description>
+    <projectUrl>https://github.com/RicoSuter/Namotion.Reflection</projectUrl>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />


### PR DESCRIPTION
This will help connect the NuGet package with this GitHub repository. The project URL is displayed on the package page on the NuGet website, and also on the NuGet package manager integrated with Visual Studio.