### PR TITLE
Cache not found result for GetXmlDocsPath

### DIFF
--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -420,7 +420,7 @@ namespace Namotion.Reflection
                 return null;
             }
 
-            document = XDocument.Load(pathToXmlFile, LoadOptions.PreserveWhitespace);
+            document = new CachingXDocument(pathToXmlFile);
             Cache[assemblyName.FullName] = document;
 
             return document;


### PR DESCRIPTION
While improving NSwag performance I found that my disk was hit with a lot of I/O. This was caused by `GetXmlDocsPath` always re-checking if the XML file would have appeared on the side of the DLL, but we don't generate XML documentation files. So a lot of calls were made.

Fixed issue by setting cache to null value for given assembly after all lookups have failed. Also replaced couple double retrievals (`ContainsKey` + indexing) with `TryGetValue`.

With my Fluid-optimized NSwag against real workload generation time dropped from 12 seconds to 8 seconds.