### PR TITLE
Create CachingXDocument that also caches member resolution

### DIFF
--- a/src/Namotion.Reflection/Performance/CachingXDocument.cs
+++ b/src/Namotion.Reflection/Performance/CachingXDocument.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace Namotion.Reflection
+{
+    /// <summary>
+    /// Caching layer hiding the details of of accessing DLL documentation.
+    /// </summary>
+    internal class CachingXDocument
+    {
+        private static readonly object Lock = new();
+        private static readonly Dictionary<string, XElement?> ElementByNameCache = new();
+
+        private static readonly XName XNameDoc = "doc";
+        private static readonly XName XNameMembers = "members";
+        private static readonly XName XNameMember = "member";
+        private static readonly XName XNameName = "name";
+
+        private readonly XDocument _document;
+
+        internal CachingXDocument(string? pathToXmlFile)
+        {
+            // can later change to document streaming if needed
+            var doc = XDocument.Load(pathToXmlFile, LoadOptions.PreserveWhitespace);
+            _document = doc;
+        }
+
+        internal XElement? GetXmlDocsElement(string name)
+        {
+            lock (Lock)
+            {
+                if (!ElementByNameCache.TryGetValue(name, out var element))
+                {
+                    element = GetXmlDocsElement(_document, name);
+
+                    ElementByNameCache[name] = element;
+                }
+                return element;
+            }
+        }
+
+        internal static XElement? GetXmlDocsElement(XDocument document, string name)
+        {
+            foreach (var e in document.Element(XNameDoc).Element(XNameMembers).Elements(XNameMember))
+            {
+                if (e.Attribute(XNameName)?.Value == name)
+                {
+                    return e;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -37,7 +37,7 @@ namespace Namotion.Reflection
     public static class XmlDocsExtensions
     {
         private static readonly object Lock = new object();
-        private static readonly Dictionary<string, XDocument?> Cache = new Dictionary<string, XDocument?>(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, CachingXDocument?> Cache = new Dictionary<string, CachingXDocument?>(StringComparer.OrdinalIgnoreCase);
 
         internal static void ClearCache()
         {
@@ -166,7 +166,7 @@ namespace Namotion.Reflection
         {
             lock (Lock)
             {
-                return ((MemberInfo)type.GetTypeInfo()).GetXmlDocsWithoutLock(pathToXmlFile);
+                return type.GetTypeInfo().GetXmlDocsWithoutLock(pathToXmlFile);
             }
         }
 
@@ -258,7 +258,6 @@ namespace Namotion.Reflection
                     return null;
                 }
 
-                var assemblyName = parameter.Member.Module.Assembly.GetName();
                 lock (Lock)
                 {
                     return GetXmlDocumentationWithoutLock(parameter, pathToXmlFile);
@@ -403,9 +402,9 @@ namespace Namotion.Reflection
             }
         }
 
-        private static XDocument? TryGetXmlDocsDocument(AssemblyName assemblyName, string? pathToXmlFile)
+        private static CachingXDocument? TryGetXmlDocsDocument(AssemblyName assemblyName, string? pathToXmlFile)
         {
-            if (!Cache.ContainsKey(assemblyName.FullName))
+            if (!Cache.TryGetValue(assemblyName.FullName, out var document))
             {
                 if (pathToXmlFile is null)
                 {
@@ -417,10 +416,11 @@ namespace Namotion.Reflection
                     return null;
                 }
 
-                Cache[assemblyName.FullName] = XDocument.Load(pathToXmlFile, LoadOptions.PreserveWhitespace);
+                document = new CachingXDocument(pathToXmlFile);
+                Cache[assemblyName.FullName] = document;
             }
 
-            return Cache[assemblyName.FullName];
+            return document;
         }
 
         private static bool IsAssemblyIgnored(AssemblyName assemblyName)
@@ -433,35 +433,34 @@ namespace Namotion.Reflection
             return false;
         }
 
-        private static XElement? GetXmlDocsElement(this MemberInfo member, XDocument xml)
+        private static XElement? GetXmlDocsElement(this MemberInfo member, CachingXDocument xml)
         {
             var name = GetMemberElementName(member);
-            return GetXmlDocsElement(xml, name);
+            return xml.GetXmlDocsElement(name);
         }
 
         internal static XElement? GetXmlDocsElement(this XDocument xml, string name)
         {
             var result = (IEnumerable)DynamicApis.XPathEvaluate(xml, $"/doc/members/member[@name='{name}']");
-            return result.OfType<XElement>().FirstOrDefault();
+            return CachingXDocument.GetXmlDocsElement(xml, name);
         }
 
-        private static XElement? GetXmlDocsElement(this ParameterInfo parameter, XDocument xml)
+        private static XElement? GetXmlDocsElement(this ParameterInfo parameter, CachingXDocument xml)
         {
             var name = GetMemberElementName(parameter.Member);
-            var result = (IEnumerable)DynamicApis.XPathEvaluate(xml, $"/doc/members/member[@name='{name}']");
-
-            var element = result.OfType<XElement>().FirstOrDefault();
+            var element = xml.GetXmlDocsElement(name);
             if (element != null)
             {
                 ReplaceInheritdocElements(parameter.Member, element);
 
+                IEnumerable result;
                 if (parameter.IsRetval || string.IsNullOrEmpty(parameter.Name))
                 {
-                    result = (IEnumerable)DynamicApis.XPathEvaluate(xml, $"/doc/members/member[@name='{name}']/returns");
+                    result = element.Elements("returns");
                 }
                 else
                 {
-                    result = (IEnumerable)DynamicApis.XPathEvaluate(xml, $"/doc/members/member[@name='{name}']/param[@name='{parameter.Name}']");
+                    result = element.Elements("param").Where(x => x.Attribute("name")?.Value == parameter.Name);
                 }
 
                 return result.OfType<XElement>().FirstOrDefault();


### PR DESCRIPTION
New abstraction for loaded XML, allows later optimizations and different strategies. By using element iteration instead of XPath and caching member resolution memory allocation decreases and performance improves. Same member was shown to be resolved multiple times for document usage. 

Tested against Squidex on command line by generating the OpenAPI specification, otherwise optimized NSwag run time,

Master: `Duration: 00:00:03.6076498`
This branch: `Duration: 00:00:02.9206038`