### PR TITLE
Make GetXmlDocsPath public and inheritdoc cref= functionality

### DIFF
--- a/src/Namotion.Reflection/.editorconfig
+++ b/src/Namotion.Reflection/.editorconfig
@@ -1,0 +1,23 @@
+﻿
+[*.cs]
+
+# Microsoft .NET properties
+csharp_indent_braces = false
+csharp_new_line_before_open_brace = control_blocks,local_functions,methods,types
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+# ReSharper properties
+resharper_blank_lines_after_block_statements = 0
+resharper_blank_lines_after_control_transfer_statements = 1
+resharper_case_block_braces = end_of_line
+resharper_csharp_max_line_length = 135
+resharper_csharp_space_within_parentheses = false
+resharper_int_align_binary_expressions = false
+resharper_int_align_nested_ternary = false
+resharper_nested_ternary_style = compact
+resharper_place_simple_embedded_statement_on_same_line = false
+resharper_space_within_array_access_brackets = false
+resharper_space_within_array_rank_brackets = false
+resharper_space_within_if_parentheses = false
+resharper_space_within_while_parentheses = false

--- a/src/Namotion.Reflection/Performance/CachingXDocument.cs
+++ b/src/Namotion.Reflection/Performance/CachingXDocument.cs
@@ -4,7 +4,7 @@ using System.Xml.Linq;
 namespace Namotion.Reflection
 {
     /// <summary>
-    /// Caching layer hiding the details of of accessing DLL documentation.
+    /// Caching layer hiding the details of accessing DLL documentation.
     /// </summary>
     internal class CachingXDocument
     {

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -687,7 +687,10 @@ namespace Namotion.Reflection
             return string.Format("{0}:{1}", prefixCode, memberName.Replace("+", "."));
         }
 
-        private static string? GetXmlDocsPath(dynamic? assembly)
+        /// <summary>
+        /// Retrieve path to XML documentation for <paramref name="assembly"/>
+        /// </summary>
+        public static string? GetXmlDocsPath(Assembly? assembly)
         {
             try
             {

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -690,113 +690,97 @@ namespace Namotion.Reflection
         /// <summary>
         /// Retrieve path to XML documentation for <paramref name="assembly"/>
         /// </summary>
+
+#if NETSTANDARD1_0
+        public static string? GetXmlDocsPath( dynamic? assembly ) {
+#else
+            
         public static string? GetXmlDocsPath(Assembly? assembly)
         {
-            try
-            {
-                if (assembly == null)
-                {
+#endif
+            try {
+                if ( assembly == null ) {
                     return null;
                 }
 
                 AssemblyName assemblyName = assembly.GetName();
-                if (string.IsNullOrEmpty(assemblyName.Name))
-                {
+                if ( string.IsNullOrEmpty( assemblyName.Name ) ) {
                     return null;
                 }
 
                 var assemblyFullName = assemblyName.FullName;
-                if (Cache.ContainsKey(assemblyFullName))
-                {
+                if ( Cache.ContainsKey( assemblyFullName ) ) {
                     return null;
                 }
 
-                try
-                {
-                    string? path;
-                    if (!string.IsNullOrEmpty(assembly.Location))
-                    {
-                        var assemblyDirectory = DynamicApis.PathGetDirectoryName((string)assembly.Location);
-                        path = DynamicApis.PathCombine(assemblyDirectory, assemblyName.Name + ".xml");
-                        if (DynamicApis.FileExists(path))
-                        {
+                try {
+                    string? path = assembly?.Location;
+                    if ( path is not null && !String.IsNullOrEmpty( path ) ) {
+                        var assemblyDirectory = DynamicApis.PathGetDirectoryName(path);
+                        path = DynamicApis.PathCombine( assemblyDirectory, assemblyName.Name + ".xml" );
+                        if ( DynamicApis.FileExists( path ) ) {
                             return path;
                         }
                     }
 
-                    if (ObjectExtensions.HasProperty(assembly, "CodeBase"))
-                    {
-                        var codeBase = (string)assembly.CodeBase;
-                        if (!string.IsNullOrEmpty(codeBase))
-                        {
-                            path = DynamicApis.PathCombine(DynamicApis.PathGetDirectoryName(codeBase
-                                .Replace("file:///", string.Empty)), assemblyName.Name + ".xml")
-                                .Replace("file:\\", string.Empty);
+                    if ( ObjectExtensions.HasProperty( assembly, "CodeBase" ) ) {
+                        var codeBase = (string)assembly?.CodeBase;
+                        if ( !string.IsNullOrEmpty( codeBase ) ) {
+                            path = DynamicApis.PathCombine( DynamicApis.PathGetDirectoryName( codeBase
+                                .Replace( "file:///", string.Empty ) ), assemblyName.Name + ".xml" )
+                                .Replace( "file:\\", string.Empty );
 
-                            if (DynamicApis.FileExists(path))
-                            {
+                            if ( DynamicApis.FileExists( path ) ) {
                                 return path;
                             }
                         }
                     }
 
                     var currentDomain = Type.GetType("System.AppDomain")?.GetRuntimeProperty("CurrentDomain")?.GetValue(null);
-                    if (currentDomain?.HasProperty("BaseDirectory") == true)
-                    {
+                    if ( currentDomain?.HasProperty( "BaseDirectory" ) == true ) {
                         var baseDirectory = currentDomain.TryGetPropertyValue("BaseDirectory", "");
-                        if (!string.IsNullOrEmpty(baseDirectory))
-                        {
-                            path = DynamicApis.PathCombine(baseDirectory, assemblyName.Name + ".xml");
-                            if (DynamicApis.FileExists(path))
-                            {
+                        if ( !string.IsNullOrEmpty( baseDirectory ) ) {
+                            path = DynamicApis.PathCombine( baseDirectory, assemblyName.Name + ".xml" );
+                            if ( DynamicApis.FileExists( path ) ) {
                                 return path;
                             }
 
-                            path = DynamicApis.PathCombine(baseDirectory, "bin/" + assemblyName.Name + ".xml");
-                            if (DynamicApis.FileExists(path))
-                            {
+                            path = DynamicApis.PathCombine( baseDirectory, "bin/" + assemblyName.Name + ".xml" );
+                            if ( DynamicApis.FileExists( path ) ) {
                                 return path;
                             }
                         }
                     }
 
                     var currentDirectory = DynamicApis.DirectoryGetCurrentDirectory();
-                    path = DynamicApis.PathCombine(currentDirectory, assembly.GetName().Name + ".xml");
-                    if (DynamicApis.FileExists(path))
-                    {
+                    path = DynamicApis.PathCombine( currentDirectory, assembly.GetName().Name + ".xml" );
+                    if ( DynamicApis.FileExists( path ) ) {
                         return path;
                     }
 
-                    path = DynamicApis.PathCombine(currentDirectory, "bin/" + assembly.GetName().Name + ".xml");
-                    if (DynamicApis.FileExists(path))
-                    {
+                    path = DynamicApis.PathCombine( currentDirectory, "bin/" + assembly.GetName().Name + ".xml" );
+                    if ( DynamicApis.FileExists( path ) ) {
                         return path;
                     }
 
                     dynamic? executingAssembly = typeof(Assembly)
                         .GetRuntimeMethod("GetExecutingAssembly", new Type[0])?
                         .Invoke(null, new object[0]);
-                    if (!string.IsNullOrEmpty(executingAssembly?.Location))
-                    {
+                    if ( !string.IsNullOrEmpty( executingAssembly?.Location ) ) {
                         var assemblyDirectory = DynamicApis.PathGetDirectoryName((string)executingAssembly!.Location);
-                        path = GetXmlDocsPathFromNuGetCacheOrDotNetSdk(assemblyDirectory, assemblyName);
-                        if (path != null && DynamicApis.FileExists(path))
-                        {
+                        path = GetXmlDocsPathFromNuGetCacheOrDotNetSdk( assemblyDirectory, assemblyName );
+                        if ( path != null && DynamicApis.FileExists( path ) ) {
                             return path;
                         }
                     }
 
-                    Cache[assemblyFullName] = null;
+                    Cache[ assemblyFullName ] = null;
+                    return null;
+                } catch {
+                    Cache[ assemblyFullName ] = null;
                     return null;
                 }
-                catch
-                {
-                    Cache[assemblyFullName] = null;
-                    return null;
-                }
-            }
-            catch
-            {
+            } catch {
                 return null;
             }
         }


### PR DESCRIPTION
- Make GetXmlDocsPath public
- add additional functionality for cref= inheritdoc
- added `.editorconfig` reflecting existing formatting styles