### PR TITLE
Optimize nullable reference type handling

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ steps:
   displayName: 'Install .NET Core SDK'
   inputs:
     packageType: 'sdk'
-    version: '5.0.102'
+    version: '6.0.100'
 
 # Patch preview project versions (only when on master branch)
 - task: CmdLine@2

--- a/src/Namotion.Reflection.Benchmark/Namotion.Reflection.Benchmark.csproj
+++ b/src/Namotion.Reflection.Benchmark/Namotion.Reflection.Benchmark.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Namotion.Reflection.Benchmark/Namotion.Reflection.Benchmark.csproj
+++ b/src/Namotion.Reflection.Benchmark/Namotion.Reflection.Benchmark.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NBench" Version="1.0.4" />
     <PackageReference Include="Pro.NBench.xUnit" Version="1.0.4" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>

--- a/src/Namotion.Reflection.Cecil.Tests/Namotion.Reflection.Cecil.Tests.csproj
+++ b/src/Namotion.Reflection.Cecil.Tests/Namotion.Reflection.Cecil.Tests.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Namotion.Reflection.Cecil.Tests/Namotion.Reflection.Cecil.Tests.csproj
+++ b/src/Namotion.Reflection.Cecil.Tests/Namotion.Reflection.Cecil.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/Namotion.Reflection.Demo/Namotion.Reflection.Demo.csproj
+++ b/src/Namotion.Reflection.Demo/Namotion.Reflection.Demo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Namotion.Reflection.Tests/Namotion.Reflection.Tests.csproj
+++ b/src/Namotion.Reflection.Tests/Namotion.Reflection.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NJsonSchema" Version="10.1.5" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Namotion.Reflection.Tests/Namotion.Reflection.Tests.csproj
+++ b/src/Namotion.Reflection.Tests/Namotion.Reflection.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>9.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Namotion.Reflection/Context/ContextualFieldInfo.cs
+++ b/src/Namotion.Reflection/Context/ContextualFieldInfo.cs
@@ -14,15 +14,18 @@ namespace Namotion.Reflection
         internal ContextualFieldInfo(FieldInfo fieldInfo, ref int nullableFlagsIndex, byte[]? nullableFlags)
         {
             FieldInfo = fieldInfo;
+
+            var attributeProviders = fieldInfo.DeclaringType.IsNested
+                ? new [] { NullableFlagsSource.Create(fieldInfo.DeclaringType), NullableFlagsSource.Create(fieldInfo.DeclaringType.DeclaringType, fieldInfo.DeclaringType.GetTypeInfo().Assembly) }
+                : new [] { NullableFlagsSource.Create(fieldInfo.DeclaringType, fieldInfo.DeclaringType.GetTypeInfo().Assembly) };
+
             FieldType = new ContextualType(
                fieldInfo.FieldType,
                fieldInfo.GetCustomAttributes(true).OfType<Attribute>().ToArray(),
                null,
                ref nullableFlagsIndex,
                nullableFlags,
-               fieldInfo.DeclaringType.IsNested ?
-                   new dynamic[] { fieldInfo.DeclaringType, fieldInfo.DeclaringType.DeclaringType, fieldInfo.DeclaringType.GetTypeInfo().Assembly } :
-                   new dynamic[] { fieldInfo.DeclaringType, fieldInfo.DeclaringType.GetTypeInfo().Assembly });
+               attributeProviders);
         }
 
         /// <summary>

--- a/src/Namotion.Reflection/Context/ContextualPropertyInfo.cs
+++ b/src/Namotion.Reflection/Context/ContextualPropertyInfo.cs
@@ -17,15 +17,18 @@ namespace Namotion.Reflection
         internal ContextualPropertyInfo(PropertyInfo propertyInfo, ref int nullableFlagsIndex, byte[]? nullableFlags)
         {
             PropertyInfo = propertyInfo;
+
+            var attributeProviders = propertyInfo.DeclaringType.IsNested
+                ? new [] { NullableFlagsSource.Create(propertyInfo.DeclaringType), NullableFlagsSource.Create(propertyInfo.DeclaringType.DeclaringType, propertyInfo.DeclaringType.GetTypeInfo().Assembly) }
+                : new [] { NullableFlagsSource.Create(propertyInfo.DeclaringType, propertyInfo.DeclaringType.GetTypeInfo().Assembly) };
+
             PropertyType = new ContextualType(
                 propertyInfo.PropertyType,
                 propertyInfo.GetCustomAttributes(true).OfType<Attribute>().ToArray(),
-                null, 
-                ref nullableFlagsIndex, 
+                null,
+                ref nullableFlagsIndex,
                 nullableFlags,
-                propertyInfo.DeclaringType.IsNested ?
-                    new dynamic[] { propertyInfo.DeclaringType, propertyInfo.DeclaringType.DeclaringType, propertyInfo.DeclaringType.GetTypeInfo().Assembly } :
-                    new dynamic[] { propertyInfo.DeclaringType, propertyInfo.DeclaringType.GetTypeInfo().Assembly });
+                attributeProviders);
         }
 
         /// <summary>

--- a/src/Namotion.Reflection/Context/NullableFlagsSource.cs
+++ b/src/Namotion.Reflection/Context/NullableFlagsSource.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit {}
+}
+
+namespace Namotion.Reflection
+{
+    internal readonly struct NullableFlagsSource
+    {
+        private readonly record struct CacheKey(Type Type, Assembly? Assembly);
+        private static Dictionary<CacheKey, NullableFlagsSource> _typeToAttributeSource = new();
+
+        public readonly byte[]? NullableFlags;
+
+        public static NullableFlagsSource Create(Type type, Assembly? assembly = null)
+        {
+            var sourceMapping = _typeToAttributeSource;
+
+            var key = new CacheKey(type, assembly);
+            if (!sourceMapping.TryGetValue(key, out var source))
+            {
+                // this is racy logic, but benefits from less synchronization primitives and faster reads
+                source = new NullableFlagsSource(type, assembly);
+                Interlocked.CompareExchange(ref _typeToAttributeSource, new Dictionary<CacheKey, NullableFlagsSource>(_typeToAttributeSource)
+                {
+                    [key] = source
+                }, sourceMapping);
+            }
+
+            return source;
+        }
+
+        public static NullableFlagsSource Create(MemberInfo member)
+        {
+            return new NullableFlagsSource(member);
+        }
+
+        private NullableFlagsSource(Type type, Assembly? assembly)
+        {
+            byte[]? flags = null;
+
+            // assembly level is the normal case
+            if (assembly is not null)
+            {
+                flags = GetNullableFlags(assembly);
+            }
+
+            if (flags is null)
+            {
+                // search type
+                flags = GetNullableFlags(type);
+            }
+
+            NullableFlags = flags;
+        }
+
+        private NullableFlagsSource(MemberInfo memberInfo)
+        {
+            NullableFlags = GetNullableFlags(memberInfo);
+        }
+
+#if !NETSTANDARD1_0 && !NET40
+        private static byte[]? GetNullableFlags(ICustomAttributeProvider provider)
+        {
+            var attributes = provider.GetCustomAttributes(false);
+            foreach (var attribute in attributes)
+            {
+                var type = attribute.GetType();
+                if (type.Name == "NullableContextAttribute" && type.Namespace == "System.Runtime.CompilerServices")
+                {
+#if NET40
+                    return new byte[] { (byte) type.GetField("Flag").GetValue(attribute) };
+#else
+                    return new byte[] { (byte) type.GetRuntimeField("Flag").GetValue(attribute) };
+#endif
+                }
+            }
+
+            return null;
+        }
+#else
+        private static byte[]? GetNullableFlags(object provider)
+        {
+            var attributes = (IEnumerable<Attribute>) ((dynamic) provider).GetCustomAttributes(false);
+            foreach (var attribute in attributes)
+            {
+                var type = attribute.GetType();
+                if (type.Name == "NullableContextAttribute" && type.Namespace == "System.Runtime.CompilerServices")
+                {
+#if NET40
+                    return new byte[] { (byte) type.GetField("Flag").GetValue(attribute) };
+#else
+                    return new byte[] { (byte) type.GetRuntimeField("Flag").GetValue(attribute) };
+#endif
+                }
+            }
+
+            return null;
+        }
+#endif
+
+    }
+}

--- a/src/Namotion.Reflection/Namotion.Reflection.csproj
+++ b/src/Namotion.Reflection/Namotion.Reflection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard1.0;netstandard2.0;net40;net45</TargetFrameworks>
-    <LangVersion>9</LangVersion>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>../Namotion.Reflection.snk</AssemblyOriginatorKeyFile>

--- a/src/Namotion.Reflection/Performance/CachingXDocument.cs
+++ b/src/Namotion.Reflection/Performance/CachingXDocument.cs
@@ -6,7 +6,7 @@ namespace Namotion.Reflection
     /// <summary>
     /// Caching layer hiding the details of accessing DLL documentation.
     /// </summary>
-    internal class CachingXDocument
+    internal sealed class CachingXDocument
     {
         private static readonly object Lock = new();
         private static readonly Dictionary<string, XElement?> ElementByNameCache = new();

--- a/src/Namotion.Reflection/Performance/PropertyReader.cs
+++ b/src/Namotion.Reflection/Performance/PropertyReader.cs
@@ -15,7 +15,7 @@ namespace Namotion.Reflection
         }
     }
 
-    internal class PropertyReader<TObject, TValue> : IPropertyReader
+    internal sealed class PropertyReader<TObject, TValue> : IPropertyReader
     {
         private readonly PropertyInfo _propertyInfo;
 #if !NET40 && !NETSTANDARD1_0

--- a/src/Namotion.Reflection/Performance/PropertyWriter.cs
+++ b/src/Namotion.Reflection/Performance/PropertyWriter.cs
@@ -15,7 +15,7 @@ namespace Namotion.Reflection
         }
     }
 
-    internal class PropertyWriter<TObject, TValue> : IPropertyWriter
+    internal sealed class PropertyWriter<TObject, TValue> : IPropertyWriter
     {
         private readonly PropertyInfo _propertyInfo;
 #if !NET40 && !NETSTANDARD1_0

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -621,8 +621,8 @@ namespace Namotion.Reflection
                             (((dynamic)x.ParameterType).GenericTypeArguments.Length > 0 ?
                                 x.ParameterType.Namespace + "." + x.ParameterType.Name.Split('`')[0] +
                                     "{" + string.Join(",", ((Type[])((dynamic)x.ParameterType).GenericTypeArguments)
-                                        .Select(a => a.IsGenericParameter ? 
-                                            "||" + a.GenericParameterPosition.ToString() : 
+                                        .Select(a => a.IsGenericParameter ?
+                                            "||" + a.GenericParameterPosition.ToString() :
                                             a.Namespace + "." + a.Name + "[[||0]]")) // special case for Expression<Func...>>
                                     + "}" :
                                 "||" + x.ParameterType.GenericParameterPosition)) :
@@ -795,16 +795,16 @@ namespace Namotion.Reflection
                 var fullAssemblyVersion = (assembly as Assembly)?.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version;
                 if (fullAssemblyVersion == null)
                     return null;
-            
+
                 var version = new Version(fullAssemblyVersion);
                 // NuGet cache only has the Major.Minor.Build version
                 var truncatedVersion = $"{version.Major}.{version.Minor}.{version.Build}";
                 // Path is like /Users/usernamehere/.nuget/packages/Microsoft.AspNetCore.Mvc.Core/2.2.1
                 var macOsPath = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.Personal), 
-                    ".nuget", 
+                    Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+                    ".nuget",
                     "packages",
-                    assemblyName.Name, 
+                    assemblyName.Name,
                     truncatedVersion);
 
                 if (!Directory.Exists(macOsPath))
@@ -825,6 +825,8 @@ namespace Namotion.Reflection
             return DynamicApis.PathCombine(assemblyDirectory, assemblyName.Name + ".xml");
         }
 
+        private static readonly Regex runtimeConfigRegex = new Regex("\"((.*?)((\\\\\\\\)|(////))(.*?))\"", RegexOptions.IgnoreCase);
+
         private static string? GetXmlDocsPathFromNuGetCacheOrDotNetSdk(string assemblyDirectory, AssemblyName assemblyName)
         {
             var configs = DynamicApis.DirectoryGetAllFiles(assemblyDirectory, "*.runtimeconfig.dev.json");
@@ -834,7 +836,7 @@ namespace Namotion.Reflection
                 {
                     // Retrieve NuGet package cache directories from *.runtimeconfig.dev.json
                     var json = DynamicApis.FileReadAllText(configs.First());
-                    var matches = Regex.Matches(json, $"\"((.*?)((\\\\\\\\)|(////))(.*?))\"", RegexOptions.IgnoreCase);
+                    var matches = runtimeConfigRegex.Matches(json);
                     if (matches.Count > 0)
                     {
                         foreach (Match match in matches)

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -857,13 +857,13 @@ namespace Namotion.Reflection
                                     var packagePath = DynamicApis.PathCombine(path, assemblyName.Name + "/" + assemblyName.Version.ToString(3));
                                     if (DynamicApis.DirectoryExists(packagePath))
                                     {
-                                        var files = DynamicApis.DirectoryGetAllFiles(packagePath, assemblyName.Name + ".xml")
-                                            .OrderBy(f => f)
-                                            .ToArray();
+                                        var file = DynamicApis.DirectoryGetAllFiles(packagePath, assemblyName.Name + ".xml")
+                                            .OrderByDescending(f => f)
+                                            .FirstOrDefault();
 
-                                        if (files.Any())
+                                        if (file is not null)
                                         {
-                                            return files.Last();
+                                            return file;
                                         }
                                     }
                                 }
@@ -882,14 +882,15 @@ namespace Namotion.Reflection
                                         try
                                         {
                                             path = DynamicApis.PathCombine(path, "packs");
-                                            var files = DynamicApis.DirectoryGetAllFiles(path, assemblyName.Name + ".xml")
-                                               .OrderBy(f => f)
-                                               .Where(f => f.Replace('\\', '/').Contains("/" + assemblyName.Version.ToString(2)))
-                                               .ToArray();
+                                            var search = "/" + assemblyName.Version.ToString(2);
+                                            var file = DynamicApis.DirectoryGetAllFiles(path, assemblyName.Name + ".xml")
+                                               .Where(f => f.Replace('\\', '/').Contains(search))
+                                               .OrderByDescending(f => f)
+                                               .FirstOrDefault();
 
-                                            if (files.Any())
+                                            if (file is not null)
                                             {
-                                                return files.Last();
+                                                return file;
                                             }
                                         }
                                         catch


### PR DESCRIPTION
`GetFlagsFromCustomAttributeProviders` showed up in NSwag generation as really hot method (and taking a lot of time). This accumulates as the information is loaded per type and all its members.

The old logic basically caused always search to member's type and assembly, using `GetCustomAttributes`, using dynamic object. 

Now:

* only using dynamic on old runtimes, other ones now use `ICustomAttributeProvider`
* using separate struct to store resolution result, caching result per type / assembly
   * method/property resolution is still done, but fallback to type/assembly won't be so costly
* better cache keys that do not require string concatenation on lookup (C# 10 feature)
* updated build to happen on NET 6 SDK

Tested the chain and no changes in client output for our nullable reference type -enabled project.

## Benchmark

Need to clear the cache to show the first hit problem.

```csharp
[MemoryDiagnoser]
public class ContextualPropertyBenchmark
{
    [Benchmark]
    public void GetContextualProperties()
    {
        CachedType.ClearCache();
        typeof(JsonSchema).GetContextualProperties();
    }
}
```

## Results

``` ini
BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
Intel Core i7-6820HQ CPU 2.70GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.100
  [Host]     : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
  DefaultJob : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
```

### Before

|                  Method |     Mean |     Error |    StdDev |   Gen 0 | Allocated |
|------------------------ |---------:|----------:|----------:|--------:|----------:|
| GetContextualProperties | 1.755 ms | 0.0283 ms | 0.0265 ms | 95.7031 |    394 KB |


### After

|                  Method |     Mean |   Error |  StdDev |   Gen 0 |  Gen 1 | Allocated |
|------------------------ |---------:|--------:|--------:|--------:|-------:|----------:|
| GetContextualProperties | 306.1 μs | 5.65 μs | 5.01 μs | 20.5078 | 0.9766 |     86 KB |