### PR TITLE
Reduce LINQ related allocations

### DIFF
--- a/src/Namotion.Reflection/Context/CachedType.cs
+++ b/src/Namotion.Reflection/Context/CachedType.cs
@@ -179,7 +179,7 @@ namespace Namotion.Reflection
         public T? GetInheritedAttribute<T>()
             where T : Attribute
         {
-            return InheritedAttributes.GetFirstOrDefault<T>();
+            return InheritedAttributes.GetSingleOrDefault<T>();
         }
 
         /// <summary>

--- a/src/Namotion.Reflection/Context/CachedType.cs
+++ b/src/Namotion.Reflection/Context/CachedType.cs
@@ -179,7 +179,7 @@ namespace Namotion.Reflection
         public T? GetInheritedAttribute<T>()
             where T : Attribute
         {
-            return InheritedAttributes.OfType<T>().SingleOrDefault();
+            return InheritedAttributes.GetFirstOrDefault<T>();
         }
 
         /// <summary>

--- a/src/Namotion.Reflection/Context/ContextualAccessorInfo.cs
+++ b/src/Namotion.Reflection/Context/ContextualAccessorInfo.cs
@@ -43,7 +43,7 @@ namespace Namotion.Reflection
         /// <returns>The attribute or null.</returns>
         public T? GetContextAttribute<T>()
         {
-            return ContextAttributes.OfType<T>().SingleOrDefault();
+            return ContextAttributes.GetFirstOrDefault<T>();
         }
 
         /// <summary>

--- a/src/Namotion.Reflection/Context/ContextualAccessorInfo.cs
+++ b/src/Namotion.Reflection/Context/ContextualAccessorInfo.cs
@@ -43,7 +43,7 @@ namespace Namotion.Reflection
         /// <returns>The attribute or null.</returns>
         public T? GetContextAttribute<T>()
         {
-            return ContextAttributes.GetFirstOrDefault<T>();
+            return ContextAttributes.GetSingleOrDefault<T>();
         }
 
         /// <summary>

--- a/src/Namotion.Reflection/Context/ContextualType.cs
+++ b/src/Namotion.Reflection/Context/ContextualType.cs
@@ -211,7 +211,7 @@ namespace Namotion.Reflection
         /// <returns>The attribute or null.</returns>
         public T? GetContextAttribute<T>() where T : Attribute
         {
-            return ContextAttributes.GetFirstOrDefault<T>();
+            return ContextAttributes.GetSingleOrDefault<T>();
         }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace Namotion.Reflection
         /// <returns>The attribute or null.</returns>
         public T? GetAttribute<T>()
         {
-            return ContextAttributes.GetFirstOrDefault<T>() ?? InheritedAttributes.GetFirstOrDefault<T>();
+            return ContextAttributes.GetSingleOrDefault<T>() ?? InheritedAttributes.GetSingleOrDefault<T>();
         }
 
         /// <summary>

--- a/src/Namotion.Reflection/Context/ContextualType.cs
+++ b/src/Namotion.Reflection/Context/ContextualType.cs
@@ -209,9 +209,9 @@ namespace Namotion.Reflection
         /// </summary>
         /// <typeparam name="T">The attribute type.</typeparam>
         /// <returns>The attribute or null.</returns>
-        public T? GetContextAttribute<T>()
+        public T? GetContextAttribute<T>() where T : Attribute
         {
-            return ContextAttributes.OfType<T>().SingleOrDefault();
+            return ContextAttributes.GetFirstOrDefault<T>();
         }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace Namotion.Reflection
         /// <returns>The attribute or null.</returns>
         public T? GetAttribute<T>()
         {
-            return ContextAttributes.OfType<T>().Concat(InheritedAttributes.OfType<T>()).FirstOrDefault();
+            return ContextAttributes.GetFirstOrDefault<T>() ?? InheritedAttributes.GetFirstOrDefault<T>();
         }
 
         /// <summary>

--- a/src/Namotion.Reflection/EnumerableExtensions.cs
+++ b/src/Namotion.Reflection/EnumerableExtensions.cs
@@ -66,16 +66,27 @@ namespace Namotion.Reflection
             return typeof(object);
         }
 
-        internal static T? GetFirstOrDefault<T>(this Attribute[] attributes)
+        internal static T? GetSingleOrDefault<T>(this Attribute[] attributes)
         {
+            static void ThrowInvalidOperation()
+            {
+                throw new InvalidOperationException("Found more than one element");
+            }
+
+            T? found = default;
             foreach (var attribute in attributes)
             {
                 if (attribute is T typed)
                 {
-                    return typed;
+                    if (found is not null)
+                    {
+                        ThrowInvalidOperation();
+                    }
+
+                    found = typed;
                 }
             }
-            return default;
+            return found;
         }
     }
 }

--- a/src/Namotion.Reflection/EnumerableExtensions.cs
+++ b/src/Namotion.Reflection/EnumerableExtensions.cs
@@ -65,5 +65,17 @@ namespace Namotion.Reflection
 
             return typeof(object);
         }
+
+        internal static T? GetFirstOrDefault<T>(this Attribute[] attributes)
+        {
+            foreach (var attribute in attributes)
+            {
+                if (attribute is T typed)
+                {
+                    return typed;
+                }
+            }
+            return default;
+        }
     }
 }

--- a/src/Namotion.Reflection/EnumerableExtensions.cs
+++ b/src/Namotion.Reflection/EnumerableExtensions.cs
@@ -25,7 +25,13 @@ namespace Namotion.Reflection
         /// <returns>The objects which are assignable.</returns>
         public static IEnumerable<T> GetAssignableToTypeName<T>(this IEnumerable<T> objects, string typeName, TypeNameStyle typeNameStyle = TypeNameStyle.FullName)
         {
-            return objects.Where(o => o!.GetType().IsAssignableToTypeName(typeName, typeNameStyle));
+            foreach (T o in objects)
+            {
+                if (o.GetType().IsAssignableToTypeName(typeName, typeNameStyle))
+                {
+                    yield return o;
+                }
+            }
         }
 
         /// <summary>Tries to get the first object which is assignable to the given type name.</summary>

--- a/src/Namotion.Reflection/TypeExtensions.cs
+++ b/src/Namotion.Reflection/TypeExtensions.cs
@@ -42,14 +42,26 @@ namespace Namotion.Reflection
                 return true;
             }
 
-            return type.InheritsFromTypeName(typeName, typeNameStyle) ||
+            if (type.InheritsFromTypeName(typeName, typeNameStyle))
+            {
+                return true;
+            }
+
 #if NETSTANDARD1_0
-                (typeNameStyle == TypeNameStyle.Name && type.GetTypeInfo().ImplementedInterfaces.Any(i => i.Name == typeName)) ||
-                (typeNameStyle == TypeNameStyle.FullName && type.GetTypeInfo().ImplementedInterfaces.Any(i => i.FullName == typeName));
+            var interfaces = type.GetTypeInfo().ImplementedInterfaces;
 #else
-                (typeNameStyle == TypeNameStyle.Name && type.GetInterfaces().Any(i => i.Name == typeName)) ||
-                (typeNameStyle == TypeNameStyle.FullName && type.GetInterfaces().Any(i => i.FullName == typeName));
+            var interfaces = type.GetInterfaces();
 #endif
+            foreach (var i in interfaces)
+            {
+                if (typeNameStyle == TypeNameStyle.Name && i.Name == typeName
+                    || typeNameStyle == TypeNameStyle.FullName && i.FullName == typeName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>Checks whether the given type inherits from the given type name.</summary>


### PR DESCRIPTION
Top allocations come LINQ-enabled helpers that have capturing closures causing always to allocate. Changed code to boring loop code that does not allocate `Func`s.

![image](https://user-images.githubusercontent.com/171892/144809650-3443626a-a3d4-4075-a8e1-3c33255d6b93.png)
