### PR TITLE
Reduce char and string array allocations

### DIFF
--- a/src/Namotion.Reflection/Context/CachedType.cs
+++ b/src/Namotion.Reflection/Context/CachedType.cs
@@ -195,7 +195,7 @@ namespace Namotion.Reflection
         /// <inheritdocs />
         public override string ToString()
         {
-            var result = Type.Name.Split('`').First() + "\n  " +
+            var result = Type.Name.FirstToken('`') + "\n  " +
                 string.Join("\n", GenericArguments.Select(a => a.ToString())).Replace("\n", "\n  ");
 
             return result.Trim();

--- a/src/Namotion.Reflection/Context/ContextualType.cs
+++ b/src/Namotion.Reflection/Context/ContextualType.cs
@@ -404,7 +404,7 @@ namespace Namotion.Reflection
         /// <inheritdocs />
         public override string ToString()
         {
-            var result = Type.Name.Split('`').First() + ": " + Nullability + "\n  " +
+            var result = Type.Name.FirstToken('`') + ": " + Nullability + "\n  " +
                 string.Join("\n", GenericArguments.Select(a => a.ToString())).Replace("\n", "\n  ");
 
             return result.Trim();

--- a/src/Namotion.Reflection/StringExtensions.cs
+++ b/src/Namotion.Reflection/StringExtensions.cs
@@ -1,0 +1,17 @@
+namespace Namotion.Reflection
+{
+    internal static class StringExtensions
+    {
+        public static string FirstToken(this string s, char splitChar)
+        {
+            var idx = s.IndexOf(splitChar);
+            return idx != -1 ? s.Substring(0, idx) : s;
+        }
+
+        public static string LastToken(this string s, char splitChar)
+        {
+            var idx = s.LastIndexOf(splitChar);
+            return idx != -1 ? s.Substring(idx + 1) : s;
+        }
+    }
+}

--- a/src/Namotion.Reflection/TypeExtensions.cs
+++ b/src/Namotion.Reflection/TypeExtensions.cs
@@ -149,7 +149,7 @@ namespace Namotion.Reflection
             if (nType.Type.IsGenericType)
 #endif
             {
-                return GetName(nType).Split('`').First() + "Of" +
+                return GetName(nType).FirstToken('`') + "Of" +
                        string.Join("And", nType.GenericArguments
                                                .Select(a => GetDisplayName(a.OriginalType)));
             }

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -383,6 +383,11 @@ namespace Namotion.Reflection
                             value.Append(e.Value);
                         }
                     }
+                    else if (node is XText text)
+                    {
+                        // take value directly without costly ToString()
+                        value.Append(text.Value);
+                    }
                     else
                     {
                         value.Append(node);


### PR DESCRIPTION
Using `string.Split` with multiple chars or or `string.Trim()` with any parameters causes always char array allocation on older frameworks than NET5 as its params array. Also doing Split just to get first or last token is a bit wasteful as we can write helpers than return first and last token based on split char that return the actual single string needed. 

Detecting XText node case alse saves costly ToString builder as it already has the value contained.

This method is well covered by test cases.