### PR TITLE
Added functionality to maintain formatting used in XML-docs in generated documentation.

### DIFF
--- a/src/Namotion.Reflection.Tests/XmlDocsExtensionsTests.cs
+++ b/src/Namotion.Reflection.Tests/XmlDocsExtensionsTests.cs
@@ -258,7 +258,11 @@ namespace Namotion.Reflection.Tests
             XmlDocs.ClearCache();
 
             //// Act
-            var summary = typeof(WithGenericTagsInXmlDoc).GetProperty("Foo").GetXmlDocsSummary(formattingMode: XmlDocsFormattingMode.Html);
+            XmlDocOptions options = new XmlDocOptions()
+            {
+                FormattingMode = XmlDocsFormattingMode.Html
+            };
+            var summary = typeof(WithGenericTagsInXmlDoc).GetProperty("Foo").GetXmlDocsSummary(options);
 
             //// Assert
             Assert.Equal("This <pre>are</pre> <strong>some</strong> tags.", summary);
@@ -271,7 +275,11 @@ namespace Namotion.Reflection.Tests
             XmlDocs.ClearCache();
 
             //// Act
-            var summary = typeof(WithGenericTagsInXmlDoc).GetProperty("Foo").GetXmlDocsSummary(formattingMode: XmlDocsFormattingMode.Markdown);
+            XmlDocOptions options = new XmlDocOptions()
+            {
+                FormattingMode = XmlDocsFormattingMode.Markdown
+            };
+            var summary = typeof(WithGenericTagsInXmlDoc).GetProperty("Foo").GetXmlDocsSummary(options);
 
             //// Assert
             Assert.Equal("This `are` **some** tags.", summary);

--- a/src/Namotion.Reflection.Tests/XmlDocsExtensionsTests.cs
+++ b/src/Namotion.Reflection.Tests/XmlDocsExtensionsTests.cs
@@ -251,6 +251,32 @@ namespace Namotion.Reflection.Tests
             Assert.Equal("This are some tags.", summary);
         }
 
+        [Fact]
+        public void When_summary_has_generic_tags_then_it_is_converted_to_html()
+        {
+            //// Arrange
+            XmlDocs.ClearCache();
+
+            //// Act
+            var summary = typeof(WithGenericTagsInXmlDoc).GetProperty("Foo").GetXmlDocsSummary(formattingMode: XmlDocsFormattingMode.Html);
+
+            //// Assert
+            Assert.Equal("This <pre>are</pre> <strong>some</strong> tags.", summary);
+        }
+
+        [Fact]
+        public void When_summary_has_generic_tags_then_it_is_converted_to_markdown()
+        {
+            //// Arrange
+            XmlDocs.ClearCache();
+
+            //// Act
+            var summary = typeof(WithGenericTagsInXmlDoc).GetProperty("Foo").GetXmlDocsSummary(formattingMode: XmlDocsFormattingMode.Markdown);
+
+            //// Assert
+            Assert.Equal("This `are` **some** tags.", summary);
+        }
+
         public abstract class BaseBaseClass
         {
             /// <summary>Foo.</summary>

--- a/src/Namotion.Reflection/StringBuilderExtensions.cs
+++ b/src/Namotion.Reflection/StringBuilderExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System.Text;
+
+namespace Namotion.Reflection
+{
+    /// <summary>
+    /// Contains extension for <see cref="StringBuilder"/>.
+    /// </summary>
+    public static class StringBuilderExtensions
+    {
+        /// <summary>
+        /// Allows to append multiple strings to the <see cref="StringBuilder"/> at once.
+        /// </summary>
+        /// <remarks>
+        /// Only strings that are neither <c>null</c> nor <c>string.Empty</c> will be added.
+        /// </remarks>
+        /// <param name="stringBuilder">The instance of <see cref="StringBuilder"/>.</param>
+        /// <param name="values">The values to appends.</param>
+        /// <returns>The value of <paramref name="stringBuilder"/>.</returns>
+        public static StringBuilder Append(this StringBuilder stringBuilder, params string[] values)
+        {
+            foreach (string value in values)
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    stringBuilder.Append(value);
+                }
+            }
+            return stringBuilder;
+        }
+    }
+}

--- a/src/Namotion.Reflection/StringBuilderExtensions.cs
+++ b/src/Namotion.Reflection/StringBuilderExtensions.cs
@@ -5,7 +5,7 @@ namespace Namotion.Reflection
     /// <summary>
     /// Contains extension for <see cref="StringBuilder"/>.
     /// </summary>
-    public static class StringBuilderExtensions
+    internal static class StringBuilderExtensions
     {
         /// <summary>
         /// Allows to append multiple strings to the <see cref="StringBuilder"/> at once.
@@ -16,9 +16,9 @@ namespace Namotion.Reflection
         /// <param name="stringBuilder">The instance of <see cref="StringBuilder"/>.</param>
         /// <param name="values">The values to appends.</param>
         /// <returns>The value of <paramref name="stringBuilder"/>.</returns>
-        public static StringBuilder Append(this StringBuilder stringBuilder, params string[] values)
+        public static StringBuilder Append(this StringBuilder stringBuilder, params string?[] values)
         {
-            foreach (string value in values)
+            foreach (string? value in values)
             {
                 if (!string.IsNullOrEmpty(value))
                 {
@@ -26,6 +26,44 @@ namespace Namotion.Reflection
                 }
             }
             return stringBuilder;
+        }
+
+        /// <summary>
+        /// Allows to append multiple strings to the <see cref="StringBuilder"/> at once.
+        /// </summary>
+        /// <remarks>
+        /// Only strings that are neither <c>null</c> nor <c>string.Empty</c> will be added.
+        /// </remarks>
+        /// <param name="stringBuilder">The instance of <see cref="StringBuilder"/>.</param>
+        /// <param name="value1">First value to append.</param>
+        /// <param name="value2">Second value to append.</param>
+        /// <param name="value3">Third value to append. (optional)</param>
+        /// <param name="value4">Fourth value to append. (optional)</param>
+        /// <param name="value5">Fifth value to append. (optional)</param>
+        /// <param name="value6">Sixth value to append. (optional)</param>
+        /// <returns>The value of <paramref name="stringBuilder"/>.</returns>
+        public static StringBuilder Append(this StringBuilder stringBuilder, string? value1, string? value2, string? value3 = null, string? value4 = null, string? value5 = null, string? value6 = null)
+        {
+            // Note: only value3 onwards are optional, as StringBuilder contains Append with one string so at least two must
+            // be specified to call this method
+
+            AppendStringToStringBuilder(stringBuilder, value1);
+            AppendStringToStringBuilder(stringBuilder, value2);
+            AppendStringToStringBuilder(stringBuilder, value3);
+            AppendStringToStringBuilder(stringBuilder, value4);
+            AppendStringToStringBuilder(stringBuilder, value5);
+            AppendStringToStringBuilder(stringBuilder, value6);
+
+            return stringBuilder;
+
+        }
+
+        private static void AppendStringToStringBuilder(StringBuilder stringBuilder, string? value)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                stringBuilder.Append(value);
+            }
         }
     }
 }

--- a/src/Namotion.Reflection/XmlDocOptions.cs
+++ b/src/Namotion.Reflection/XmlDocOptions.cs
@@ -13,7 +13,7 @@
         /// <summary>
         /// Specifies how formatting tags should be processed.
         /// </summary>
-        public XmlDocsFormattingMode FormattingMode { get; set; } = XmlDocsFormattingMode.Unformatted;
+        public XmlDocsFormattingMode FormattingMode { get; set; } = XmlDocsFormattingMode.None;
 
         /// <summary>
         /// Creates and initializes an instance of <see cref="XmlDocOptions"/> based on the flag <see cref="ResolveExternalXmlDocs"/>.

--- a/src/Namotion.Reflection/XmlDocOptions.cs
+++ b/src/Namotion.Reflection/XmlDocOptions.cs
@@ -1,0 +1,28 @@
+﻿namespace Namotion.Reflection
+{
+    /// <summary>
+    /// Contains all options to control generation of XML-docs.
+    /// </summary>
+    public class XmlDocOptions
+    {
+        /// <summary>
+        /// Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.
+        /// </summary>
+        public bool ResolveExternalXmlDocs { get; set; } = true;
+
+        /// <summary>
+        /// Specifies how formatting tags should be processed.
+        /// </summary>
+        public XmlDocsFormattingMode FormattingMode { get; set; } = XmlDocsFormattingMode.Unformatted;
+
+        /// <summary>
+        /// Creates and initializes an instance of <see cref="XmlDocOptions"/> based on the flag <see cref="ResolveExternalXmlDocs"/>.
+        /// </summary>
+        /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <returns>Instance of <see cref="XmlDocOptions"/> with initialized flag <see cref="ResolveExternalXmlDocs"/>.</returns>
+        internal static XmlDocOptions Create(bool resolveExternalXmlDocs)
+        {
+            return new XmlDocOptions() { ResolveExternalXmlDocs = resolveExternalXmlDocs };
+        }
+    }
+}

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -52,73 +52,131 @@ namespace Namotion.Reflection
         /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
         /// <param name="type">The type.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsSummary(this CachedType type, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocsSummary(this CachedType type, bool resolveExternalXmlDocs = true)
         {
-            return type.Type.GetXmlDocsSummary(resolveExternalXmlDocs, formattingMode);
+            return type.Type.GetXmlDocsSummary(resolveExternalXmlDocs);
+        }
+
+        /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
+        /// <param name="type">The type.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "summary" tag for the member.</returns>
+        public static string GetXmlDocsSummary(this CachedType type, XmlDocOptions options)
+        {
+            return type.Type.GetXmlDocsSummary(options);
         }
 
         /// <summary>Returns the contents of the "remarks" XML documentation tag for the specified member.</summary>
         /// <param name="type">The type.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsRemarks(this CachedType type, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocsRemarks(this CachedType type, bool resolveExternalXmlDocs = true)
         {
-            return type.Type.GetXmlDocsRemarks(resolveExternalXmlDocs, formattingMode);
+            return type.Type.GetXmlDocsRemarks(resolveExternalXmlDocs);
+        }
+
+        /// <summary>Returns the contents of the "remarks" XML documentation tag for the specified member.</summary>
+        /// <param name="type">The type.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "summary" tag for the member.</returns>
+        public static string GetXmlDocsRemarks(this CachedType type, XmlDocOptions options)
+        {
+            return type.Type.GetXmlDocsRemarks(options);
         }
 
         /// <summary>Returns the contents of an XML documentation tag for the specified member.</summary>
         /// <param name="type">The type.</param>
         /// <param name="tagName">Name of the tag.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsTag(this CachedType type, string tagName, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocsTag(this CachedType type, string tagName, bool resolveExternalXmlDocs = true)
         {
-            return type.Type.GetXmlDocsTag(tagName, resolveExternalXmlDocs, formattingMode);
+            return type.Type.GetXmlDocsTag(tagName, resolveExternalXmlDocs);
+        }
+
+        /// <summary>Returns the contents of an XML documentation tag for the specified member.</summary>
+        /// <param name="type">The type.</param>
+        /// <param name="tagName">Name of the tag.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "summary" tag for the member.</returns>
+        public static string GetXmlDocsTag(this CachedType type, string tagName, XmlDocOptions options)
+        {
+            return type.Type.GetXmlDocsTag(tagName, options);
         }
 
         /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
         /// <param name="member">The reflected member.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsSummary(this ContextualMemberInfo member, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocsSummary(this ContextualMemberInfo member, bool resolveExternalXmlDocs = true)
         {
-            return member.MemberInfo.GetXmlDocsSummary(resolveExternalXmlDocs, formattingMode);
+            return member.MemberInfo.GetXmlDocsSummary(resolveExternalXmlDocs);
+        }
+
+        /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
+        /// <param name="member">The reflected member.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "summary" tag for the member.</returns>
+        public static string GetXmlDocsSummary(this ContextualMemberInfo member, XmlDocOptions options)
+        {
+            return member.MemberInfo.GetXmlDocsSummary(options);
         }
 
         /// <summary>Returns the contents of the "remarks" XML documentation tag for the specified member.</summary>
         /// <param name="member">The reflected member.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsRemarks(this ContextualMemberInfo member, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocsRemarks(this ContextualMemberInfo member, bool resolveExternalXmlDocs = true)
         {
-            return member.MemberInfo.GetXmlDocsRemarks(resolveExternalXmlDocs, formattingMode);
+            return member.MemberInfo.GetXmlDocsRemarks(resolveExternalXmlDocs);
+        }
+
+        /// <summary>Returns the contents of the "remarks" XML documentation tag for the specified member.</summary>
+        /// <param name="member">The reflected member.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "summary" tag for the member.</returns>
+        public static string GetXmlDocsRemarks(this ContextualMemberInfo member, XmlDocOptions options)
+        {
+            return member.MemberInfo.GetXmlDocsRemarks(options);
         }
 
         /// <summary>Returns the contents of an XML documentation tag for the specified member.</summary>
         /// <param name="member">The reflected member.</param>
         /// <param name="tagName">Name of the tag.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsTag(this ContextualMemberInfo member, string tagName, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocsTag(this ContextualMemberInfo member, string tagName, bool resolveExternalXmlDocs = true)
         {
-            return member.MemberInfo.GetXmlDocsTag(tagName, resolveExternalXmlDocs, formattingMode);
+            return member.MemberInfo.GetXmlDocsTag(tagName, resolveExternalXmlDocs);
+        }
+
+        /// <summary>Returns the contents of an XML documentation tag for the specified member.</summary>
+        /// <param name="member">The reflected member.</param>
+        /// <param name="tagName">Name of the tag.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "summary" tag for the member.</returns>
+        public static string GetXmlDocsTag(this ContextualMemberInfo member, string tagName, XmlDocOptions options)
+        {
+            return member.MemberInfo.GetXmlDocsTag(tagName, options);
         }
 
         /// <summary>Returns the contents of the "returns" or "param" XML documentation tag for the specified parameter.</summary>
         /// <param name="parameter">The reflected parameter or return info.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "returns" or "param" tag.</returns>
-        public static string GetXmlDocs(this ContextualParameterInfo parameter, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocs(this ContextualParameterInfo parameter, bool resolveExternalXmlDocs = true)
         {
-            return parameter.ParameterInfo.GetXmlDocs(resolveExternalXmlDocs, formattingMode);
+            return parameter.ParameterInfo.GetXmlDocs(resolveExternalXmlDocs);
+        }
+
+        /// <summary>Returns the contents of the "returns" or "param" XML documentation tag for the specified parameter.</summary>
+        /// <param name="parameter">The reflected parameter or return info.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "returns" or "param" tag.</returns>
+        public static string GetXmlDocs(this ContextualParameterInfo parameter, XmlDocOptions options)
+        {
+            return parameter.ParameterInfo.GetXmlDocs(options);
         }
 
         /// <summary>Returns the contents of an XML documentation tag for the specified member.</summary>
@@ -135,46 +193,79 @@ namespace Namotion.Reflection
         /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
         /// <param name="type">The type.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsSummary(this Type type, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocsSummary(this Type type, bool resolveExternalXmlDocs = true)
         {
-            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), XmlDocsKeys.SummaryElement, resolveExternalXmlDocs, formattingMode);
+            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), XmlDocsKeys.SummaryElement, resolveExternalXmlDocs);
+        }
+
+        /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
+        /// <param name="type">The type.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "summary" tag for the member.</returns>
+        public static string GetXmlDocsSummary(this Type type, XmlDocOptions options)
+        {
+            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), XmlDocsKeys.SummaryElement, options);
         }
 
         /// <summary>Returns the contents of the "remarks" XML documentation tag for the specified member.</summary>
         /// <param name="type">The type.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsRemarks(this Type type, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocsRemarks(this Type type, bool resolveExternalXmlDocs = true)
         {
-            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), XmlDocsKeys.RemarksElement, resolveExternalXmlDocs, formattingMode);
+            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), XmlDocsKeys.RemarksElement, resolveExternalXmlDocs);
+        }
+
+        /// <summary>Returns the contents of the "remarks" XML documentation tag for the specified member.</summary>
+        /// <param name="type">The type.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "summary" tag for the member.</returns>
+        public static string GetXmlDocsRemarks(this Type type, XmlDocOptions options)
+        {
+            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), XmlDocsKeys.RemarksElement, options);
         }
 
         /// <summary>Returns the contents of an XML documentation tag for the specified member.</summary>
         /// <param name="type">The type.</param>
         /// <param name="tagName">Name of the tag.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsTag(this Type type, string tagName, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocsTag(this Type type, string tagName, bool resolveExternalXmlDocs = true)
         {
-            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), tagName, resolveExternalXmlDocs, formattingMode);
+            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), tagName, resolveExternalXmlDocs);
+        }
+
+        /// <summary>Returns the contents of an XML documentation tag for the specified member.</summary>
+        /// <param name="type">The type.</param>
+        /// <param name="tagName">Name of the tag.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "summary" tag for the member.</returns>
+        public static string GetXmlDocsTag(this Type type, string tagName, XmlDocOptions options)
+        {
+            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), tagName, options);
         }
 
         /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
         /// <param name="member">The reflected member.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsSummary(this MemberInfo member, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocsSummary(this MemberInfo member, bool resolveExternalXmlDocs = true)
         {
-            var docs = GetXmlDocsTag(member, XmlDocsKeys.SummaryElement, resolveExternalXmlDocs, formattingMode);
+            return GetXmlDocsSummary(member, XmlDocOptions.Create(resolveExternalXmlDocs));
+        }
+
+        /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
+        /// <param name="member">The reflected member.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "summary" tag for the member.</returns>
+        public static string GetXmlDocsSummary(this MemberInfo member, XmlDocOptions options)
+        {
+            var docs = GetXmlDocsTag(member, XmlDocsKeys.SummaryElement, options);
 
             if (string.IsNullOrEmpty(docs) && member is PropertyInfo propertyInfo)
             {
-                return propertyInfo.GetXmlDocsRecordPropertySummary(resolveExternalXmlDocs, formattingMode);
+                return propertyInfo.GetXmlDocsRecordPropertySummary(options);
             }
 
             return docs;
@@ -183,11 +274,19 @@ namespace Namotion.Reflection
         /// <summary>Returns the contents of the "remarks" XML documentation tag for the specified member.</summary>
         /// <param name="member">The reflected member.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsRemarks(this MemberInfo member, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocsRemarks(this MemberInfo member, bool resolveExternalXmlDocs = true)
         {
-            return GetXmlDocsTag(member, XmlDocsKeys.RemarksElement, resolveExternalXmlDocs, formattingMode);
+            return GetXmlDocsTag(member, XmlDocsKeys.RemarksElement, resolveExternalXmlDocs);
+        }
+
+        /// <summary>Returns the contents of the "remarks" XML documentation tag for the specified member.</summary>
+        /// <param name="member">The reflected member.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "summary" tag for the member.</returns>
+        public static string GetXmlDocsRemarks(this MemberInfo member, XmlDocOptions options)
+        {
+            return GetXmlDocsTag(member, XmlDocsKeys.RemarksElement, options);
         }
 
         /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
@@ -258,9 +357,18 @@ namespace Namotion.Reflection
         /// <param name="member">The reflected member.</param>
         /// <param name="tagName">Name of the tag.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsTag(this MemberInfo member, string tagName, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocsTag(this MemberInfo member, string tagName, bool resolveExternalXmlDocs = true)
+        {
+            return GetXmlDocsTag(member, tagName, XmlDocOptions.Create(resolveExternalXmlDocs));
+        }
+
+        /// <summary>Returns the contents of an XML documentation tag for the specified member.</summary>
+        /// <param name="member">The reflected member.</param>
+        /// <param name="tagName">Name of the tag.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "summary" tag for the member.</returns>
+        public static string GetXmlDocsTag(this MemberInfo member, string tagName, XmlDocOptions options)
         {
             if (DynamicApis.SupportsXPathApis == false || DynamicApis.SupportsFileApis == false || DynamicApis.SupportsPathApis == false)
             {
@@ -271,22 +379,30 @@ namespace Namotion.Reflection
             _ = tagName ?? throw new ArgumentNullException(nameof(tagName));
 
             var assemblyName = member.Module.Assembly.GetName();
-            if (IsAssemblyIgnored(assemblyName, resolveExternalXmlDocs))
+            if (IsAssemblyIgnored(assemblyName, options.ResolveExternalXmlDocs))
             {
                 return string.Empty;
             }
 
-            var documentationPath = GetXmlDocsPath(member.Module.Assembly, resolveExternalXmlDocs);
-            var element = GetXmlDocsElement(member, documentationPath!, resolveExternalXmlDocs);
-            return ToXmlDocsContent(element?.Element(tagName), formattingMode);
+            var documentationPath = GetXmlDocsPath(member.Module.Assembly, options.ResolveExternalXmlDocs);
+            var element = GetXmlDocsElement(member, documentationPath!, options.ResolveExternalXmlDocs);
+            return ToXmlDocsContent(element?.Element(tagName), options);
         }
 
         /// <summary>Returns the property summary of a Record type which is read from the param tag on the type.</summary>
         /// <param name="member">The reflected member.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "param" tag of the Record property.</returns>
-        public static string GetXmlDocsRecordPropertySummary(this PropertyInfo member, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocsRecordPropertySummary(this PropertyInfo member, bool resolveExternalXmlDocs = true)
+        {
+            return GetXmlDocsRecordPropertySummary(member, XmlDocOptions.Create(resolveExternalXmlDocs));
+        }
+
+        /// <summary>Returns the property summary of a Record type which is read from the param tag on the type.</summary>
+        /// <param name="member">The reflected member.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "param" tag of the Record property.</returns>
+        public static string GetXmlDocsRecordPropertySummary(this PropertyInfo member, XmlDocOptions options)
         {
             if (DynamicApis.SupportsXPathApis == false || DynamicApis.SupportsFileApis == false || DynamicApis.SupportsPathApis == false)
             {
@@ -296,27 +412,35 @@ namespace Namotion.Reflection
             _ = member ?? throw new ArgumentNullException(nameof(member));
 
             var assemblyName = member.Module.Assembly.GetName();
-            if (IsAssemblyIgnored(assemblyName, resolveExternalXmlDocs))
+            if (IsAssemblyIgnored(assemblyName, options.ResolveExternalXmlDocs))
             {
                 return string.Empty;
             }
 
-            var documentationPath = GetXmlDocsPath(member.Module.Assembly, resolveExternalXmlDocs);
-            var parentElement = GetXmlDocsElement(member.DeclaringType.GetTypeInfo(), documentationPath!, resolveExternalXmlDocs);
+            var documentationPath = GetXmlDocsPath(member.Module.Assembly, options.ResolveExternalXmlDocs);
+            var parentElement = GetXmlDocsElement(member.DeclaringType.GetTypeInfo(), documentationPath!, options.ResolveExternalXmlDocs);
             var paramElement = parentElement?
                 .Elements(XmlDocsKeys.ParamElement)?
                 .FirstOrDefault(x => x.Attribute(XmlDocsKeys.ParamNameAttribute)?
                 .Value == member.Name);
 
-            return paramElement != null ? ToXmlDocsContent(paramElement, formattingMode) : string.Empty;
+            return paramElement != null ? ToXmlDocsContent(paramElement, options) : string.Empty;
         }
 
         /// <summary>Returns the contents of the "returns" or "param" XML documentation tag for the specified parameter.</summary>
         /// <param name="parameter">The reflected parameter or return info.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "returns" or "param" tag.</returns>
-        public static string GetXmlDocs(this ParameterInfo parameter, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string GetXmlDocs(this ParameterInfo parameter, bool resolveExternalXmlDocs = true)
+        {
+            return GetXmlDocs(parameter, XmlDocOptions.Create(resolveExternalXmlDocs));
+        }
+
+        /// <summary>Returns the contents of the "returns" or "param" XML documentation tag for the specified parameter.</summary>
+        /// <param name="parameter">The reflected parameter or return info.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The contents of the "returns" or "param" tag.</returns>
+        public static string GetXmlDocs(this ParameterInfo parameter, XmlDocOptions options)
         {
             if (DynamicApis.SupportsXPathApis == false || DynamicApis.SupportsFileApis == false || DynamicApis.SupportsPathApis == false)
             {
@@ -324,14 +448,14 @@ namespace Namotion.Reflection
             }
 
             var assemblyName = parameter.Member.Module.Assembly.GetName();
-            if (IsAssemblyIgnored(assemblyName, resolveExternalXmlDocs))
+            if (IsAssemblyIgnored(assemblyName, options.ResolveExternalXmlDocs))
             {
                 return string.Empty;
             }
 
-            var documentationPath = GetXmlDocsPath(parameter.Member.Module.Assembly, resolveExternalXmlDocs);
-            var element = GetXmlDocs(parameter, documentationPath, resolveExternalXmlDocs);
-            return ToXmlDocsContent(element, formattingMode);
+            var documentationPath = GetXmlDocsPath(parameter.Member.Module.Assembly, options.ResolveExternalXmlDocs);
+            var element = GetXmlDocs(parameter, documentationPath, options.ResolveExternalXmlDocs);
+            return ToXmlDocsContent(element, options);
         }
 
         /// <summary>Returns the contents of the "returns" or "param" XML documentation tag for the specified parameter.</summary>
@@ -361,10 +485,21 @@ namespace Namotion.Reflection
 
         /// <summary>Converts the given XML documentation <see cref="XElement"/> to text.</summary>
         /// <param name="element">The XML element.</param>
-        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The text</returns>
-        public static string ToXmlDocsContent(this XElement? element, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
+        public static string ToXmlDocsContent(this XElement? element)
         {
+            XmlDocOptions options = new XmlDocOptions();
+            return ToXmlDocsContent(element, options);
+        }
+
+        /// <summary>Converts the given XML documentation <see cref="XElement"/> to text.</summary>
+        /// <param name="element">The XML element.</param>
+        /// <param name="options">Options to control formatting of the XML-docs.</param>
+        /// <returns>The text</returns>
+        public static string ToXmlDocsContent(this XElement? element, XmlDocOptions options)
+        {
+            _ = options ?? throw new ArgumentNullException(nameof(options));
+
             if (element != null)
             {
                 var value = new StringBuilder();
@@ -413,7 +548,7 @@ namespace Namotion.Reflection
                         }
                         else
                         {
-                            value.AppendFormattedElement(e, formattingMode);
+                            value.AppendFormattedElement(e, options.FormattingMode);
                         }
                     }
                     else if (node is XText text)
@@ -427,7 +562,7 @@ namespace Namotion.Reflection
                     }
                 }
 
-                return RemoveLineBreakWhiteSpaces(value.ToString(), formattingMode);
+                return RemoveLineBreakWhiteSpaces(value.ToString(), options.FormattingMode);
             }
 
             return string.Empty;

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -52,66 +52,73 @@ namespace Namotion.Reflection
         /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
         /// <param name="type">The type.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsSummary(this CachedType type, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocsSummary(this CachedType type, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
-            return type.Type.GetXmlDocsSummary(resolveExternalXmlDocs);
+            return type.Type.GetXmlDocsSummary(resolveExternalXmlDocs, formattingMode);
         }
 
         /// <summary>Returns the contents of the "remarks" XML documentation tag for the specified member.</summary>
         /// <param name="type">The type.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsRemarks(this CachedType type, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocsRemarks(this CachedType type, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
-            return type.Type.GetXmlDocsRemarks(resolveExternalXmlDocs);
+            return type.Type.GetXmlDocsRemarks(resolveExternalXmlDocs, formattingMode);
         }
 
         /// <summary>Returns the contents of an XML documentation tag for the specified member.</summary>
         /// <param name="type">The type.</param>
         /// <param name="tagName">Name of the tag.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsTag(this CachedType type, string tagName, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocsTag(this CachedType type, string tagName, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
-            return type.Type.GetXmlDocsTag(tagName, resolveExternalXmlDocs);
+            return type.Type.GetXmlDocsTag(tagName, resolveExternalXmlDocs, formattingMode);
         }
 
         /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
         /// <param name="member">The reflected member.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsSummary(this ContextualMemberInfo member, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocsSummary(this ContextualMemberInfo member, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
-            return member.MemberInfo.GetXmlDocsSummary(resolveExternalXmlDocs);
+            return member.MemberInfo.GetXmlDocsSummary(resolveExternalXmlDocs, formattingMode);
         }
 
         /// <summary>Returns the contents of the "remarks" XML documentation tag for the specified member.</summary>
         /// <param name="member">The reflected member.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsRemarks(this ContextualMemberInfo member, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocsRemarks(this ContextualMemberInfo member, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
-            return member.MemberInfo.GetXmlDocsRemarks(resolveExternalXmlDocs);
+            return member.MemberInfo.GetXmlDocsRemarks(resolveExternalXmlDocs, formattingMode);
         }
 
         /// <summary>Returns the contents of an XML documentation tag for the specified member.</summary>
         /// <param name="member">The reflected member.</param>
         /// <param name="tagName">Name of the tag.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsTag(this ContextualMemberInfo member, string tagName, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocsTag(this ContextualMemberInfo member, string tagName, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
-            return member.MemberInfo.GetXmlDocsTag(tagName, resolveExternalXmlDocs);
+            return member.MemberInfo.GetXmlDocsTag(tagName, resolveExternalXmlDocs, formattingMode);
         }
 
         /// <summary>Returns the contents of the "returns" or "param" XML documentation tag for the specified parameter.</summary>
         /// <param name="parameter">The reflected parameter or return info.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "returns" or "param" tag.</returns>
-        public static string GetXmlDocs(this ContextualParameterInfo parameter, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocs(this ContextualParameterInfo parameter, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
-            return parameter.ParameterInfo.GetXmlDocs(resolveExternalXmlDocs);
+            return parameter.ParameterInfo.GetXmlDocs(resolveExternalXmlDocs, formattingMode);
         }
 
         /// <summary>Returns the contents of an XML documentation tag for the specified member.</summary>
@@ -128,42 +135,46 @@ namespace Namotion.Reflection
         /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
         /// <param name="type">The type.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsSummary(this Type type, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocsSummary(this Type type, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
-            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), "summary", resolveExternalXmlDocs);
+            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), XmlDocsKeys.SummaryElement, resolveExternalXmlDocs, formattingMode);
         }
 
         /// <summary>Returns the contents of the "remarks" XML documentation tag for the specified member.</summary>
         /// <param name="type">The type.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsRemarks(this Type type, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocsRemarks(this Type type, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
-            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), "remarks", resolveExternalXmlDocs);
+            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), XmlDocsKeys.RemarksElement, resolveExternalXmlDocs, formattingMode);
         }
 
         /// <summary>Returns the contents of an XML documentation tag for the specified member.</summary>
         /// <param name="type">The type.</param>
         /// <param name="tagName">Name of the tag.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsTag(this Type type, string tagName, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocsTag(this Type type, string tagName, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
-            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), tagName, resolveExternalXmlDocs);
+            return GetXmlDocsTag((MemberInfo)type.GetTypeInfo(), tagName, resolveExternalXmlDocs, formattingMode);
         }
 
         /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
         /// <param name="member">The reflected member.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsSummary(this MemberInfo member, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocsSummary(this MemberInfo member, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
-            var docs = GetXmlDocsTag(member, "summary", resolveExternalXmlDocs);
+            var docs = GetXmlDocsTag(member, XmlDocsKeys.SummaryElement, resolveExternalXmlDocs, formattingMode);
 
             if (string.IsNullOrEmpty(docs) && member is PropertyInfo propertyInfo)
             {
-                return propertyInfo.GetXmlDocsRecordPropertySummary(resolveExternalXmlDocs);
+                return propertyInfo.GetXmlDocsRecordPropertySummary(resolveExternalXmlDocs, formattingMode);
             }
 
             return docs;
@@ -172,10 +183,11 @@ namespace Namotion.Reflection
         /// <summary>Returns the contents of the "remarks" XML documentation tag for the specified member.</summary>
         /// <param name="member">The reflected member.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsRemarks(this MemberInfo member, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocsRemarks(this MemberInfo member, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
-            return GetXmlDocsTag(member, "remarks", resolveExternalXmlDocs);
+            return GetXmlDocsTag(member, XmlDocsKeys.RemarksElement, resolveExternalXmlDocs, formattingMode);
         }
 
         /// <summary>Returns the contents of the "summary" XML documentation tag for the specified member.</summary>
@@ -246,8 +258,9 @@ namespace Namotion.Reflection
         /// <param name="member">The reflected member.</param>
         /// <param name="tagName">Name of the tag.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "summary" tag for the member.</returns>
-        public static string GetXmlDocsTag(this MemberInfo member, string tagName, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocsTag(this MemberInfo member, string tagName, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
             if (DynamicApis.SupportsXPathApis == false || DynamicApis.SupportsFileApis == false || DynamicApis.SupportsPathApis == false)
             {
@@ -265,14 +278,15 @@ namespace Namotion.Reflection
 
             var documentationPath = GetXmlDocsPath(member.Module.Assembly, resolveExternalXmlDocs);
             var element = GetXmlDocsElement(member, documentationPath!, resolveExternalXmlDocs);
-            return ToXmlDocsContent(element?.Element(tagName));
+            return ToXmlDocsContent(element?.Element(tagName), formattingMode);
         }
 
         /// <summary>Returns the property summary of a Record type which is read from the param tag on the type.</summary>
         /// <param name="member">The reflected member.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "param" tag of the Record property.</returns>
-        public static string GetXmlDocsRecordPropertySummary(this PropertyInfo member, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocsRecordPropertySummary(this PropertyInfo member, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
             if (DynamicApis.SupportsXPathApis == false || DynamicApis.SupportsFileApis == false || DynamicApis.SupportsPathApis == false)
             {
@@ -290,18 +304,19 @@ namespace Namotion.Reflection
             var documentationPath = GetXmlDocsPath(member.Module.Assembly, resolveExternalXmlDocs);
             var parentElement = GetXmlDocsElement(member.DeclaringType.GetTypeInfo(), documentationPath!, resolveExternalXmlDocs);
             var paramElement = parentElement?
-                .Elements("param")?
-                .FirstOrDefault(x => x.Attribute("name")?
+                .Elements(XmlDocsKeys.ParamElement)?
+                .FirstOrDefault(x => x.Attribute(XmlDocsKeys.ParamNameAttribute)?
                 .Value == member.Name);
 
-            return paramElement != null ? ToXmlDocsContent(paramElement) : string.Empty;
+            return paramElement != null ? ToXmlDocsContent(paramElement, formattingMode) : string.Empty;
         }
 
         /// <summary>Returns the contents of the "returns" or "param" XML documentation tag for the specified parameter.</summary>
         /// <param name="parameter">The reflected parameter or return info.</param>
         /// <param name="resolveExternalXmlDocs">Specifies whether tho resolve the XML Docs from the NuGet cache or .NET SDK directory.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The contents of the "returns" or "param" tag.</returns>
-        public static string GetXmlDocs(this ParameterInfo parameter, bool resolveExternalXmlDocs = true)
+        public static string GetXmlDocs(this ParameterInfo parameter, bool resolveExternalXmlDocs = true, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
             if (DynamicApis.SupportsXPathApis == false || DynamicApis.SupportsFileApis == false || DynamicApis.SupportsPathApis == false)
             {
@@ -316,7 +331,7 @@ namespace Namotion.Reflection
 
             var documentationPath = GetXmlDocsPath(parameter.Member.Module.Assembly, resolveExternalXmlDocs);
             var element = GetXmlDocs(parameter, documentationPath, resolveExternalXmlDocs);
-            return ToXmlDocsContent(element);
+            return ToXmlDocsContent(element, formattingMode);
         }
 
         /// <summary>Returns the contents of the "returns" or "param" XML documentation tag for the specified parameter.</summary>
@@ -346,8 +361,9 @@ namespace Namotion.Reflection
 
         /// <summary>Converts the given XML documentation <see cref="XElement"/> to text.</summary>
         /// <param name="element">The XML element.</param>
+        /// <param name="formattingMode">Specified how formatting tags should be processed.</param>
         /// <returns>The text</returns>
-        public static string ToXmlDocsContent(this XElement? element)
+        public static string ToXmlDocsContent(this XElement? element, XmlDocsFormattingMode formattingMode = XmlDocsFormattingMode.Unformatted)
         {
             if (element != null)
             {
@@ -356,9 +372,9 @@ namespace Namotion.Reflection
                 {
                     if (node is XElement e)
                     {
-                        if (e.Name == "see")
+                        if (e.Name == XmlDocsKeys.SeeElement)
                         {
-                            var attribute = e.Attribute("langword");
+                            var attribute = e.Attribute(XmlDocsKeys.SeeLangwordAttribute);
                             if (attribute != null)
                             {
                                 value.Append(attribute.Value);
@@ -371,7 +387,7 @@ namespace Namotion.Reflection
                                 }
                                 else
                                 {
-                                    attribute = e.Attribute("cref");
+                                    attribute = e.Attribute(XmlDocsKeys.SeeCrefAttribute);
                                     if (attribute != null)
                                     {
                                         var trimmed = attribute.Value.Trim(ToXmlDocsContentTrimChars).Trim();
@@ -381,7 +397,7 @@ namespace Namotion.Reflection
                                     }
                                     else
                                     {
-                                        attribute = e.Attribute("href");
+                                        attribute = e.Attribute(XmlDocsKeys.SeeHrefAttribute);
                                         if (attribute != null)
                                         {
                                             value.Append(attribute.Value);
@@ -390,14 +406,14 @@ namespace Namotion.Reflection
                                 }
                             }
                         }
-                        else if (e.Name == "paramref")
+                        else if (e.Name == XmlDocsKeys.ParamRefElement)
                         {
-                            var nameAttribute = e.Attribute("name");
+                            var nameAttribute = e.Attribute(XmlDocsKeys.ParamRefNameAttribute);
                             value.Append(nameAttribute?.Value ?? e.Value);
                         }
                         else
                         {
-                            value.Append(e.Value);
+                            value.AppendFormattedElement(e, formattingMode);
                         }
                     }
                     else if (node is XText text)
@@ -411,7 +427,7 @@ namespace Namotion.Reflection
                     }
                 }
 
-                return RemoveLineBreakWhiteSpaces(value.ToString());
+                return RemoveLineBreakWhiteSpaces(value.ToString(), formattingMode);
             }
 
             return string.Empty;
@@ -492,11 +508,11 @@ namespace Namotion.Reflection
                 IEnumerable result;
                 if (parameter.IsRetval || string.IsNullOrEmpty(parameter.Name))
                 {
-                    result = element.Elements("returns");
+                    result = element.Elements(XmlDocsKeys.ReturnsElement);
                 }
                 else
                 {
-                    result = element.Elements("param").Where(x => x.Attribute("name")?.Value == parameter.Name);
+                    result = element.Elements(XmlDocsKeys.ParamElement).Where(x => x.Attribute(XmlDocsKeys.ParamNameAttribute)?.Value == parameter.Name);
                 }
 
                 return result.OfType<XElement>().FirstOrDefault();
@@ -519,7 +535,7 @@ namespace Namotion.Reflection
             var children = element.Nodes().ToList();
             foreach (var child in children.OfType<XElement>())
             {
-                if (child.Name.LocalName.ToLowerInvariant() == "inheritdoc")
+                if (child.Name.LocalName.ToLowerInvariant() == XmlDocsKeys.InheritDocElement)
                 {
 #if !NETSTANDARD1_0
                     // if this a class/type
@@ -578,7 +594,7 @@ namespace Namotion.Reflection
         private static readonly char[] RemoveLineBreakWhiteSpacesTrimChars = { '\n' };
         private static readonly Regex LineBreakRegex = new("(\\n[ \\t]*)", (RegexOptions)8); // Compiled
 
-        private static string RemoveLineBreakWhiteSpaces(string? documentation)
+        private static string RemoveLineBreakWhiteSpaces(string? documentation, XmlDocsFormattingMode formattingMode)
         {
             if (string.IsNullOrEmpty(documentation))
             {

--- a/src/Namotion.Reflection/XmlDocsFormatting.cs
+++ b/src/Namotion.Reflection/XmlDocsFormatting.cs
@@ -10,7 +10,8 @@ namespace Namotion.Reflection
     /// </summary>
     internal static class XmlDocsFormatting
     {
-        private static readonly IDictionary<XmlDocsFormattingMode, Func<StringBuilder, XElement, StringBuilder>> formattingFunctions =
+        // List of methods to use for requested XML-Docs-Formatting.
+        private static readonly Dictionary<XmlDocsFormattingMode, Func<StringBuilder, XElement, StringBuilder>> formattingFunctions =
             new Dictionary<XmlDocsFormattingMode, Func<StringBuilder, XElement, StringBuilder>>()
             {
                 { XmlDocsFormattingMode.Unformatted, AppendUnformattedElement },
@@ -32,7 +33,6 @@ namespace Namotion.Reflection
             return formattingFunctions[formattingMode](stringBuilder, element);
         }
 
-        #region No formatting
         /// <summary>
         /// Appends the value of <paramref name="element"/> without any formatting information.
         /// </summary>
@@ -44,9 +44,9 @@ namespace Namotion.Reflection
             stringBuilder.Append(element.Value);
             return stringBuilder;
         }
-        #endregion
-        #region HTML formatting
-        private static readonly IDictionary<string, Func<StringBuilder, XElement, StringBuilder>> htmlTagMap =
+
+        // Map XML-Docs-Tags to HTML-Tags
+        private static readonly Dictionary<string, Func<StringBuilder, XElement, StringBuilder>> htmlTagMap =
             new Dictionary<string, Func<StringBuilder, XElement, StringBuilder>>()
             {
                 { "c", (sb, e) => AppendSimpleTaggedElement(sb, e, "<pre>", "</pre>") },
@@ -65,10 +65,9 @@ namespace Namotion.Reflection
         {
             return AppendMapFormattedElement(stringBuilder, element, htmlTagMap);
         }
-        #endregion
 
-        #region Markdown formatting
-        private static readonly IDictionary<string, Func<StringBuilder, XElement, StringBuilder>> markdownTagMap =
+        // Map XML-Docs-Tags to Markdown-Codes
+        private static readonly Dictionary<string, Func<StringBuilder, XElement, StringBuilder>> markdownTagMap =
             new Dictionary<string, Func<StringBuilder, XElement, StringBuilder>>()
             {
                 { "c", (sb, e) => AppendSimpleTaggedElement(sb, e, "`", "`") },
@@ -87,7 +86,6 @@ namespace Namotion.Reflection
         {
             return AppendMapFormattedElement(stringBuilder, element, markdownTagMap);
         }
-        #endregion
 
         /// <summary>
         /// Appends the value of <paramref name="element"/> surrounded by the tags specified in <paramref name="map"/> (if supported).

--- a/src/Namotion.Reflection/XmlDocsFormatting.cs
+++ b/src/Namotion.Reflection/XmlDocsFormatting.cs
@@ -14,7 +14,7 @@ namespace Namotion.Reflection
         private static readonly Dictionary<XmlDocsFormattingMode, Func<StringBuilder, XElement, StringBuilder>> formattingFunctions =
             new Dictionary<XmlDocsFormattingMode, Func<StringBuilder, XElement, StringBuilder>>()
             {
-                { XmlDocsFormattingMode.Unformatted, AppendUnformattedElement },
+                { XmlDocsFormattingMode.None, AppendUnformattedElement },
                 { XmlDocsFormattingMode.Html, AppendHtmlFormattedElement },
                 { XmlDocsFormattingMode.Markdown, AppendMarkdownFormattedElement }
             };
@@ -97,11 +97,11 @@ namespace Namotion.Reflection
         private static StringBuilder AppendMapFormattedElement(
             StringBuilder stringBuilder,
             XElement element,
-            IDictionary<string, Func<StringBuilder, XElement, StringBuilder>> map)
+            Dictionary<string, Func<StringBuilder, XElement, StringBuilder>> map)
         {
-            if (map.ContainsKey(element.Name.LocalName))
+            if (map.TryGetValue(element.Name.LocalName, out Func<StringBuilder, XElement, StringBuilder> formattingFunction))
             {
-                return map[element.Name.LocalName](stringBuilder, element);
+                return formattingFunction(stringBuilder, element);
             }
             else
             {

--- a/src/Namotion.Reflection/XmlDocsFormatting.cs
+++ b/src/Namotion.Reflection/XmlDocsFormatting.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Xml.Linq;
+
+namespace Namotion.Reflection
+{
+    /// <summary>
+    /// Contains the logic to maintain formatting of XML-doc elements.
+    /// </summary>
+    internal static class XmlDocsFormatting
+    {
+        private static readonly IReadOnlyDictionary<XmlDocsFormattingMode, Func<StringBuilder, XElement, StringBuilder>> formattingFunctions =
+            new Dictionary<XmlDocsFormattingMode, Func<StringBuilder, XElement, StringBuilder>>()
+            {
+                { XmlDocsFormattingMode.Unformatted, AppendUnformattedElement },
+                { XmlDocsFormattingMode.Html, AppendHtmlFormattedElement },
+                { XmlDocsFormattingMode.Markdown, AppendMarkdownFormattedElement }
+            };
+
+        /// <summary>
+        /// Appends the value of <paramref name="element"/> to the <paramref name="stringBuilder"/> respecting
+        /// <paramref name="formattingMode"/> to generate additional formatting information.
+        /// </summary>
+        /// <param name="stringBuilder">The current <see cref="StringBuilder"/>.</param>
+        /// <param name="element">The <see cref="XElement"/> to append.</param>
+        /// <param name="formattingMode">The <see cref="XmlDocsFormattingMode"/> for generating additional formatting tags.</param>
+        /// <returns>The passed in <paramref name="stringBuilder"/>.</returns>
+        public static StringBuilder AppendFormattedElement(this StringBuilder stringBuilder, XElement element, XmlDocsFormattingMode formattingMode)
+        {
+            // call apropriate formatting function
+            return formattingFunctions[formattingMode](stringBuilder, element);
+        }
+
+        #region No formatting
+        /// <summary>
+        /// Appends the value of <paramref name="element"/> without any formatting information.
+        /// </summary>
+        /// <param name="stringBuilder">The current <see cref="StringBuilder"/>.</param>
+        /// <param name="element">The <see cref="XElement"/> to append.</param>
+        /// <returns>The value of <paramref name="stringBuilder"/>.</returns>
+        private static StringBuilder AppendUnformattedElement(this StringBuilder stringBuilder, XElement element)
+        {
+            stringBuilder.Append(element.Value);
+            return stringBuilder;
+        }
+        #endregion
+        #region HTML formatting
+        private static readonly IReadOnlyDictionary<string, Func<StringBuilder, XElement, StringBuilder>> htmlTagMap =
+            new Dictionary<string, Func<StringBuilder, XElement, StringBuilder>>()
+            {
+                { "c", (sb, e) => AppendSimpleTaggedElement(sb, e, "<pre>", "</pre>") },
+                { "b", (sb, e) => AppendSimpleTaggedElement(sb, e, "<strong>", "</strong>") },
+                { "strong", (sb, e) => AppendSimpleTaggedElement(sb, e, "<strong>", "</strong>") },
+                { "i", (sb, e) => AppendSimpleTaggedElement(sb, e, "<i>", "</i>") }
+            };
+
+        /// <summary>
+        /// Appends the value of <paramref name="element"/> surrounded by the neccessary HTML-tags to maintain its formatting information (if supported).
+        /// </summary>
+        /// <param name="stringBuilder">The current <see cref="StringBuilder"/>.</param>
+        /// <param name="element">The <see cref="XElement"/> to append.</param>
+        /// <returns>The value of <paramref name="stringBuilder"/>.</returns>
+        private static StringBuilder AppendHtmlFormattedElement(StringBuilder stringBuilder, XElement element)
+        {
+            return AppendMapFormattedElement(stringBuilder, element, htmlTagMap);
+        }
+        #endregion
+
+        #region Markdown formatting
+        private static readonly IReadOnlyDictionary<string, Func<StringBuilder, XElement, StringBuilder>> markdownTagMap =
+            new Dictionary<string, Func<StringBuilder, XElement, StringBuilder>>()
+            {
+                { "c", (sb, e) => AppendSimpleTaggedElement(sb, e, "`", "`") },
+                { "b", (sb, e) => AppendSimpleTaggedElement(sb, e, "**", "**") },
+                { "strong", (sb, e) => AppendSimpleTaggedElement(sb, e, "**", "**") },
+                { "i", (sb, e) => AppendSimpleTaggedElement(sb, e, "*", "*") }
+            };
+
+        /// <summary>
+        /// Appends the value of <paramref name="element"/> surrounded by the neccessary Markdown-tags to maintain its formatting information (if supported).
+        /// </summary>
+        /// <param name="stringBuilder">The current <see cref="StringBuilder"/>.</param>
+        /// <param name="element">The <see cref="XElement"/> to append.</param>
+        /// <returns>The value of <paramref name="stringBuilder"/>.</returns>
+        private static StringBuilder AppendMarkdownFormattedElement(StringBuilder stringBuilder, XElement element)
+        {
+            return AppendMapFormattedElement(stringBuilder, element, markdownTagMap);
+        }
+        #endregion
+
+        /// <summary>
+        /// Appends the value of <paramref name="element"/> surrounded by the tags specified in <paramref name="map"/> (if supported).
+        /// </summary>
+        /// <param name="stringBuilder">The current <see cref="StringBuilder"/>.</param>
+        /// <param name="element">The <see cref="XElement"/> to append.</param>
+        /// <param name="map">Map of formatting tags.</param>
+        /// <returns>The value of <paramref name="stringBuilder"/>.</returns>
+        private static StringBuilder AppendMapFormattedElement(
+            StringBuilder stringBuilder,
+            XElement element,
+            IReadOnlyDictionary<string, Func<StringBuilder, XElement, StringBuilder>> map)
+        {
+            if (map.ContainsKey(element.Name.LocalName))
+            {
+                return map[element.Name.LocalName](stringBuilder, element);
+            }
+            else
+            {
+                return AppendUnformattedElement(stringBuilder, element);
+            }
+        }
+
+        /// <summary>
+        /// Appends the value of <paramref name="element"/> surrounded by <paramref name="startTag"/> and <paramref name="endTag"/>
+        /// to maintain its formatting information (if supported).
+        /// </summary>
+        /// <param name="stringBuilder">The current <see cref="StringBuilder"/>.</param>
+        /// <param name="element">The <see cref="XElement"/> to append.</param>
+        /// <param name="startTag">The start-tag.</param>
+        /// <param name="endTag">The end-tag.</param>
+        /// <returns>The value of <paramref name="stringBuilder"/>.</returns>
+        private static StringBuilder AppendSimpleTaggedElement(StringBuilder stringBuilder, XElement element, string startTag, string endTag)
+        {
+            stringBuilder.Append(startTag, element.Value, endTag);
+            return stringBuilder;
+        }
+    }
+}

--- a/src/Namotion.Reflection/XmlDocsFormatting.cs
+++ b/src/Namotion.Reflection/XmlDocsFormatting.cs
@@ -10,7 +10,7 @@ namespace Namotion.Reflection
     /// </summary>
     internal static class XmlDocsFormatting
     {
-        private static readonly IReadOnlyDictionary<XmlDocsFormattingMode, Func<StringBuilder, XElement, StringBuilder>> formattingFunctions =
+        private static readonly IDictionary<XmlDocsFormattingMode, Func<StringBuilder, XElement, StringBuilder>> formattingFunctions =
             new Dictionary<XmlDocsFormattingMode, Func<StringBuilder, XElement, StringBuilder>>()
             {
                 { XmlDocsFormattingMode.Unformatted, AppendUnformattedElement },
@@ -46,7 +46,7 @@ namespace Namotion.Reflection
         }
         #endregion
         #region HTML formatting
-        private static readonly IReadOnlyDictionary<string, Func<StringBuilder, XElement, StringBuilder>> htmlTagMap =
+        private static readonly IDictionary<string, Func<StringBuilder, XElement, StringBuilder>> htmlTagMap =
             new Dictionary<string, Func<StringBuilder, XElement, StringBuilder>>()
             {
                 { "c", (sb, e) => AppendSimpleTaggedElement(sb, e, "<pre>", "</pre>") },
@@ -68,7 +68,7 @@ namespace Namotion.Reflection
         #endregion
 
         #region Markdown formatting
-        private static readonly IReadOnlyDictionary<string, Func<StringBuilder, XElement, StringBuilder>> markdownTagMap =
+        private static readonly IDictionary<string, Func<StringBuilder, XElement, StringBuilder>> markdownTagMap =
             new Dictionary<string, Func<StringBuilder, XElement, StringBuilder>>()
             {
                 { "c", (sb, e) => AppendSimpleTaggedElement(sb, e, "`", "`") },
@@ -99,7 +99,7 @@ namespace Namotion.Reflection
         private static StringBuilder AppendMapFormattedElement(
             StringBuilder stringBuilder,
             XElement element,
-            IReadOnlyDictionary<string, Func<StringBuilder, XElement, StringBuilder>> map)
+            IDictionary<string, Func<StringBuilder, XElement, StringBuilder>> map)
         {
             if (map.ContainsKey(element.Name.LocalName))
             {

--- a/src/Namotion.Reflection/XmlDocsFormattingMode.cs
+++ b/src/Namotion.Reflection/XmlDocsFormattingMode.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// Doesn't use any formatting.
         /// </summary>
-        Unformatted,
+        None,
 
         /// <summary>
         /// Maintains formatting through HTML-tags.

--- a/src/Namotion.Reflection/XmlDocsFormattingMode.cs
+++ b/src/Namotion.Reflection/XmlDocsFormattingMode.cs
@@ -1,0 +1,23 @@
+﻿namespace Namotion.Reflection
+{
+    /// <summary>
+    /// Contains the formatting modes supported.
+    /// </summary>
+    public enum XmlDocsFormattingMode
+    {
+        /// <summary>
+        /// Doesn't use any formatting.
+        /// </summary>
+        Unformatted,
+
+        /// <summary>
+        /// Maintains formatting through HTML-tags.
+        /// </summary>
+        Html,
+
+        /// <summary>
+        /// Maintains formatting through Markdown-tags.
+        /// </summary>
+        Markdown
+    }
+}

--- a/src/Namotion.Reflection/XmlDocsKeys.cs
+++ b/src/Namotion.Reflection/XmlDocsKeys.cs
@@ -1,0 +1,68 @@
+﻿namespace Namotion.Reflection
+{
+    /// <summary>
+    /// Contains constants for element and attribute names use in XML-docs.
+    /// </summary>
+    internal static class XmlDocsKeys
+    {
+        /// <summary>
+        /// Name of the summary element.
+        /// </summary>
+        public const string SummaryElement = "summary";
+
+        /// <summary>
+        /// Name of the remarks element.
+        /// </summary>
+        public const string RemarksElement = "remarks";
+
+        /// <summary>
+        /// Name of the param element.
+        /// </summary>
+        public const string ParamElement = "param";
+
+        /// <summary>
+        /// Name of the name attribute used in conjunction with the <see cref="ParamElement"/>.
+        /// </summary>
+        public const string ParamNameAttribute = "name";
+
+        /// <summary>
+        /// Name of the paramref element.
+        /// </summary>
+        public const string ParamRefElement = "paramref";
+
+        /// <summary>
+        /// Name of the name attribute used in conjunction with the <see cref="ParamRefElement"/>.
+        /// </summary>
+        public const string ParamRefNameAttribute = "name";
+
+        /// <summary>
+        /// Name of the see element.
+        /// </summary>
+        public const string SeeElement = "see";
+
+        /// <summary>
+        /// Name of the langword attribute used in conjunction with the <see cref="SeeElement"/>.
+        /// </summary>
+        public const string SeeLangwordAttribute = "langword";
+
+        /// <summary>
+        /// Name of the cref attribute used in conjunction with the <see cref="SeeElement"/>.
+        /// </summary>
+        public const string SeeCrefAttribute = "cref";
+
+        /// <summary>
+        /// Name of the href attribute used in conjunction with the <see cref="SeeElement"/>.
+        /// </summary>
+        public const string SeeHrefAttribute = "href";
+
+        /// <summary>
+        /// Name of the returns element.
+        /// </summary>
+        public const string ReturnsElement = "returns";
+
+        /// <summary>
+        /// Name of the inheritdoc element.
+        /// </summary>
+        public const string InheritDocElement = "inheritdoc";
+    }
+}


### PR DESCRIPTION
Supported target formats are HTML and Markdown.
The methods in `XmlDocsExtensions` introduce a new parameter which allows the caller to specify the target format. The default value is `XmlDocsFormattingMode.Unformatted`, which results in exactly the same result as the library worked before.

This pull request is created in response to the issue https://github.com/RicoSuter/NSwag/issues/3422.

It adds support for XML-docs tags `<c>...</c>`, `<b>...</b>`, `<strong>...</strong>` and `<u>...</u>`.
If you like my solution so far, I'd move on to add support for `<code>...</code>`, `<list>...</list>` and `<para>...</para>`.

Additionally, the keywords (names of elements and attributes) of XML-docs are now declared as string constants.
