### PR TITLE
Fix GetXmlDocsPathFromNuGetCacheOrDotNetSdk too eager file search

### DIFF
--- a/src/Namotion.Reflection/Infrastructure/DynamicApis.cs
+++ b/src/Namotion.Reflection/Infrastructure/DynamicApis.cs
@@ -138,7 +138,7 @@ namespace Namotion.Reflection.Infrastructure
 #endif
         }
 
-        /// <summary>Gets all files of directory.</summary>
+        /// <summary>Gets all files of directory and its sub-directories.</summary>
         /// <param name="path">The directory path.</param>
         /// <param name="searchPattern">The search pattern.</param>
         /// <returns>true or false</returns>
@@ -154,6 +154,25 @@ namespace Namotion.Reflection.Infrastructure
                 .Invoke(null, new object[] { path, searchPattern, 1 });
 #else
             return Directory.GetFiles(path, searchPattern, SearchOption.AllDirectories);
+#endif
+        }
+
+        /// <summary>Gets all files of directory.</summary>
+        /// <param name="path">The directory path.</param>
+        /// <param name="searchPattern">The search pattern.</param>
+        /// <returns>true or false</returns>
+        /// <exception cref="NotSupportedException">The System.IO.Directory API is not available on this platform.</exception>
+        public static string[] DirectoryGetFiles(string path, string searchPattern)
+        {
+#if NETSTANDARD1_0
+            if (!SupportsDirectoryApis)
+                throw new NotSupportedException("The System.IO.Directory API is not available on this platform.");
+
+            return (string[])DirectoryType!.GetRuntimeMethods()
+                .First(m => m.Name == "GetFiles" && m.GetParameters().Length == 2)
+                .Invoke(null, new object[] { path, searchPattern });
+#else
+            return Directory.GetFiles(path, searchPattern);
 #endif
         }
 

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -1001,7 +1001,7 @@ namespace Namotion.Reflection
 
         private static string? GetXmlDocsPathFromNuGetCacheOrDotNetSdk(string assemblyDirectory, AssemblyName assemblyName)
         {
-            var configs = DynamicApis.DirectoryGetAllFiles(assemblyDirectory, "*.runtimeconfig.dev.json");
+            var configs = DynamicApis.DirectoryGetFiles(assemblyDirectory, "*.runtimeconfig.dev.json");
             if (configs.Any())
             {
                 try


### PR DESCRIPTION
Now only trying to find `*.runtimeconfig.dev.json` from assembly's own directory. Added extra method to `DynamicApis` and clarified existing ones behavior. Scanning entire Docker image can be costly when app has been installed to root...

[See relevant discussion and final analysis](https://github.com/RicoSuter/NSwag/issues/3496#issuecomment-1206454859)

fixes https://github.com/RicoSuter/NSwag/issues/3496