### PR TITLE
Fix SpecialFolder.Personal usage

### DIFF
--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -976,7 +976,7 @@ namespace Namotion.Reflection
                 var truncatedVersion = $"{version.Major}.{version.Minor}.{version.Build}";
                 // Path is like /Users/usernamehere/.nuget/packages/Microsoft.AspNetCore.Mvc.Core/2.2.1
                 var macOsPath = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.Personal),
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                     ".nuget",
                     "packages",
                     assemblyName.Name,


### PR DESCRIPTION
SpecialFolder Personal is the same value as MyDocuments, both of which will be changed on Unix from `~` to `~/Documents` in .NET 8. See https://github.com/dotnet/runtime/pull/68610.

Fixing the usage of SpecialFolder.Personal here to be UserProfile, since that's really what it wants.