### PR TITLE
Add net8.0 target

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,21 +4,21 @@
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.9" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageVersion Include="Microsoft.AspNetCore.OData" Version="8.0.4" />
-    <PackageVersion Include="Microsoft.CSharp" Version="4.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.OData" Version="8.2.5" />
+    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Mono.Cecil" Version="0.11.5" />
     <PackageVersion Include="NBench" Version="1.0.4" />
-    <PackageVersion Include="NJsonSchema" Version="10.1.5" />
+    <PackageVersion Include="NJsonSchema" Version="11.0.2" />
     <PackageVersion Include="Pro.NBench.xUnit" Version="1.0.4" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
     <PackageVersion Include="xunit" Version="2.5.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" PrivateAssets="all" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <GlobalPackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <GlobalPackageReference Include="PolySharp" Version="1.14.1" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,21 +1,25 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageVersion Include="Microsoft.AspNetCore.OData" Version="8.2.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.OData" Version="9.1.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="Mono.Cecil" Version="0.11.5" />
+    <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
     <PackageVersion Include="NBench" Version="1.0.4" />
     <PackageVersion Include="NJsonSchema" Version="11.0.2" />
     <PackageVersion Include="Pro.NBench.xUnit" Version="1.0.4" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
-    <PackageVersion Include="xunit" Version="2.5.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageVersion Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.OData" Version="8.0.4" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageVersion Include="Mono.Cecil" Version="0.10.3" />
+    <PackageVersion Include="Mono.Cecil" Version="0.11.5" />
     <PackageVersion Include="NBench" Version="1.0.4" />
     <PackageVersion Include="NJsonSchema" Version="10.1.5" />
     <PackageVersion Include="Pro.NBench.xUnit" Version="1.0.4" />
@@ -18,7 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <GlobalPackageReference Include="PolySharp" Version="1.13.2" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <GlobalPackageReference Include="PolySharp" Version="1.14.1" />
   </ItemGroup>
 </Project>

--- a/src/Namotion.Reflection.Benchmark/GeneralBenchmarks.cs
+++ b/src/Namotion.Reflection.Benchmark/GeneralBenchmarks.cs
@@ -2,9 +2,7 @@
 using Pro.NBench.xUnit.XunitExtensions;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading.Tasks;
-using Xunit.Abstractions;
 
 namespace Namotion.Reflection.Benchmark
 {
@@ -31,12 +29,6 @@ namespace Namotion.Reflection.Benchmark
         }
 
         private Counter _counter = default!;
-
-        public GeneralBenchmarks(ITestOutputHelper output)
-        {
-            Trace.Listeners.Clear();
-            Trace.Listeners.Add(new XunitTraceListener(output));
-        }
 
         [PerfSetup]
         public void Setup(BenchmarkContext context)

--- a/src/Namotion.Reflection.Benchmark/Namotion.Reflection.Benchmark.csproj
+++ b/src/Namotion.Reflection.Benchmark/Namotion.Reflection.Benchmark.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Namotion.Reflection.Benchmark/Namotion.Reflection.Benchmark.csproj
+++ b/src/Namotion.Reflection.Benchmark/Namotion.Reflection.Benchmark.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NBench" />
     <PackageReference Include="Pro.NBench.xUnit" />
+    <PackageReference Include="System.Reflection.Metadata" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/src/Namotion.Reflection.Cecil.Tests/Namotion.Reflection.Cecil.Tests.csproj
+++ b/src/Namotion.Reflection.Cecil.Tests/Namotion.Reflection.Cecil.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/Namotion.Reflection.Cecil.Tests/Namotion.Reflection.Cecil.Tests.csproj
+++ b/src/Namotion.Reflection.Cecil.Tests/Namotion.Reflection.Cecil.Tests.csproj
@@ -9,7 +9,6 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/src/Namotion.Reflection.Demo/Namotion.Reflection.Demo.csproj
+++ b/src/Namotion.Reflection.Demo/Namotion.Reflection.Demo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Namotion.Reflection.Tests/GenericsTests.cs
+++ b/src/Namotion.Reflection.Tests/GenericsTests.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Reflection;
+﻿using System.Linq;
 using Xunit;
 
 namespace Namotion.Reflection.Tests

--- a/src/Namotion.Reflection.Tests/Namotion.Reflection.Tests.csproj
+++ b/src/Namotion.Reflection.Tests/Namotion.Reflection.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Namotion.Reflection/Context/NullableFlagsSource.cs
+++ b/src/Namotion.Reflection/Context/NullableFlagsSource.cs
@@ -3,11 +3,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 
-namespace System.Runtime.CompilerServices
-{
-    internal static class IsExternalInit {}
-}
-
 namespace Namotion.Reflection
 {
     internal readonly struct NullableFlagsSource

--- a/src/Namotion.Reflection/Infrastructure/DynamicApis.cs
+++ b/src/Namotion.Reflection/Infrastructure/DynamicApis.cs
@@ -86,16 +86,7 @@ namespace Namotion.Reflection.Infrastructure
         /// <exception cref="NotSupportedException">The System.IO.Directory API is not available on this platform.</exception>
         public static string[] DirectoryGetFiles(string path, string searchPattern)
         {
-#if NETSTANDARD1_0
-            if (!SupportsDirectoryApis)
-                throw new NotSupportedException("The System.IO.Directory API is not available on this platform.");
-
-            return (string[])DirectoryType!.GetRuntimeMethods()
-                .First(m => m.Name == "GetFiles" && m.GetParameters().Length == 2)
-                .Invoke(null, new object[] { path, searchPattern });
-#else
             return Directory.GetFiles(path, searchPattern);
-#endif
         }
 
         /// <summary>Combines two paths.</summary>

--- a/src/Namotion.Reflection/Namotion.Reflection.csproj
+++ b/src/Namotion.Reflection/Namotion.Reflection.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <SignAssembly>True</SignAssembly>

--- a/src/Namotion.Reflection/Namotion.Reflection.csproj
+++ b/src/Namotion.Reflection/Namotion.Reflection.csproj
@@ -1,27 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
-    <Nullable>enable</Nullable>
-    <SignAssembly>True</SignAssembly>
-    <AssemblyOriginatorKeyFile>../Namotion.Reflection.snk</AssemblyOriginatorKeyFile>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.1.1</Version>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageIconUrl>https://raw.githubusercontent.com/RicoSuter/Namotion.Reflection/master/assets/NuGetIcon.png</PackageIconUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Description>.NET library with advanced reflection APIs like XML documentation reading, Null Reference Types (C# 8) reflection and string based type checks.</Description>
-    <PackageProjectUrl>https://github.com/RicoSuter/Namotion.Reflection</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>https://github.com/RicoSuter/Namotion.Reflection.git</RepositoryUrl>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.CSharp" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+        <SignAssembly>True</SignAssembly>
+        <AssemblyOriginatorKeyFile>../Namotion.Reflection.snk</AssemblyOriginatorKeyFile>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Version>3.1.1</Version>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageIconUrl>https://raw.githubusercontent.com/RicoSuter/Namotion.Reflection/master/assets/NuGetIcon.png</PackageIconUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <Description>.NET library with advanced reflection APIs like XML documentation reading, Null Reference Types (C# 8) reflection and string based type checks.</Description>
+        <PackageProjectUrl>https://github.com/RicoSuter/Namotion.Reflection</PackageProjectUrl>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <RepositoryUrl>https://github.com/RicoSuter/Namotion.Reflection.git</RepositoryUrl>
+    </PropertyGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.CSharp" />
+    </ItemGroup>
     <ItemGroup>
         <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>

--- a/src/Namotion.Reflection/Namotion.Reflection.csproj
+++ b/src/Namotion.Reflection/Namotion.Reflection.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <SignAssembly>True</SignAssembly>

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -1104,9 +1104,7 @@ namespace Namotion.Reflection
             }
         }
 
-#if !NET40
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         private static string GetCacheKey(string assemblyFullName, bool resolveExternalXmlDocs)
         {
             return $"{assemblyFullName}:{resolveExternalXmlDocs}";


### PR DESCRIPTION
This removes the need for having `Microsoft.CSharp` reference for the [NuGet package](https://www.nuget.org/packages/Namotion.Reflection#dependencies-body-tab) when consumed from NET 6.0+ project.

fixes #145