### PR TITLE
Convert to use Central Package Management

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,24 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.13.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.OData" Version="8.0.4" />
+    <PackageVersion Include="Microsoft.CSharp" Version="4.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageVersion Include="Mono.Cecil" Version="0.10.3" />
+    <PackageVersion Include="NBench" Version="1.0.4" />
+    <PackageVersion Include="NJsonSchema" Version="10.1.5" />
+    <PackageVersion Include="Pro.NBench.xUnit" Version="1.0.4" />
+    <PackageVersion Include="xunit" Version="2.5.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <GlobalPackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <GlobalPackageReference Include="PolySharp" Version="1.13.2" />
+  </ItemGroup>
+</Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,19 +8,13 @@ pr:
 - master
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-2022'
 
 variables:
   BuildConfiguration: Release
   Projects: '**/*.csproj'
 
 steps:
-# Install required SDKs and tools
-- task: UseDotNet@2
-  displayName: 'Install .NET Core SDK'
-  inputs:
-    packageType: 'sdk'
-    version: '6.0.100'
 
 # Patch preview project versions (only when on master branch)
 - task: CmdLine@2

--- a/src/Namotion.Reflection.Benchmark/Namotion.Reflection.Benchmark.csproj
+++ b/src/Namotion.Reflection.Benchmark/Namotion.Reflection.Benchmark.csproj
@@ -1,17 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NBench" Version="1.0.4" />
-    <PackageReference Include="Pro.NBench.xUnit" Version="1.0.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NBench" />
+    <PackageReference Include="Pro.NBench.xUnit" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Namotion.Reflection\Namotion.Reflection.csproj" />

--- a/src/Namotion.Reflection.Cecil.Tests/Namotion.Reflection.Cecil.Tests.csproj
+++ b/src/Namotion.Reflection.Cecil.Tests/Namotion.Reflection.Cecil.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
@@ -9,10 +9,10 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Mono.Cecil" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Namotion.Reflection.Cecil\Namotion.Reflection.Cecil.csproj" />

--- a/src/Namotion.Reflection.Cecil/Namotion.Reflection.Cecil.csproj
+++ b/src/Namotion.Reflection.Cecil/Namotion.Reflection.Cecil.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://github.com/RicoSuter/Namotion.Reflection</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.3" />
+    <PackageReference Include="Mono.Cecil" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Namotion.Reflection\Namotion.Reflection.csproj" />

--- a/src/Namotion.Reflection.Tests/Namotion.Reflection.Tests.csproj
+++ b/src/Namotion.Reflection.Tests/Namotion.Reflection.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
@@ -8,15 +8,14 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IsExternalInit" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NJsonSchema" Version="10.1.5" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="NJsonSchema" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">
-    <PackageReference Include="Microsoft.AspNetCore.OData" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.OData" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Namotion.Reflection.Tests.FullAssembly\Namotion.Reflection.Tests.FullAssembly.csproj" />

--- a/src/Namotion.Reflection.sln
+++ b/src/Namotion.Reflection.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		..\azure-pipelines.yml = ..\azure-pipelines.yml
 		..\README.md = ..\README.md
+		..\Directory.Packages.props = ..\Directory.Packages.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Namotion.Reflection.Demo", "Namotion.Reflection.Demo\Namotion.Reflection.Demo.csproj", "{A6268E5A-0AA1-452D-BCAC-BCF0C38B6DFC}"

--- a/src/Namotion.Reflection/Namotion.Reflection.csproj
+++ b/src/Namotion.Reflection/Namotion.Reflection.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://github.com/RicoSuter/Namotion.Reflection</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
Because why not. Updated testing libs and switched from ExternalInit package to Polysharp. Updated build agent image version to get better experience (and non-failing build).