### PR TITLE
Improved XML documentation path for Mac and Linux

### DIFF
--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -740,7 +740,8 @@ namespace Namotion.Reflection
                     string? path;
                     if (!string.IsNullOrEmpty(assembly.Location))
                     {
-                        path = GetPathByOs(assembly, assemblyName);
+                        var assemblyDirectory = DynamicApis.PathGetDirectoryName((string)assembly.Location);
+                        path = DynamicApis.PathCombine(assemblyDirectory, assemblyName.Name + ".xml");
 
                         if (DynamicApis.FileExists(path))
                         {
@@ -799,6 +800,12 @@ namespace Namotion.Reflection
 
                     if (options.ResolveExternalXmlDocs)
                     {
+                        path = GetXmlDocsPathFromOSXNuGetCache(assembly, assemblyName);
+                        if (DynamicApis.FileExists(path))
+                        {
+                            return path;
+                        }
+
                         dynamic? executingAssembly = typeof(Assembly)
                             .GetRuntimeMethod("GetExecutingAssembly", new Type[0])?
                             .Invoke(null, new object[0]);
@@ -943,7 +950,7 @@ namespace Namotion.Reflection
                 .Replace("+", string.Empty);
         }
 
-        private static string? GetPathByOs(dynamic? assembly, AssemblyName assemblyName)
+        private static string? GetXmlDocsPathFromOSXNuGetCache(dynamic? assembly, AssemblyName assemblyName)
         {
 #if NETSTANDARD2_0_OR_GREATER
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -972,7 +979,7 @@ namespace Namotion.Reflection
                 return file;
             }
 #endif
-            return GetXmlAssemblyFilePathForWindows(assembly, assemblyName);
+            return null;
         }
 
         private static string GetXmlAssemblyFilePathForWindows(dynamic? assembly, AssemblyName assemblyName)

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -758,6 +758,15 @@ namespace Namotion.Reflection
                                 .Replace("file:///", string.Empty)), assemblyName.Name + ".xml")
                                 .Replace("file:\\", string.Empty);
 
+#if NETSTANDARD2_0_OR_GREATER
+                            // If running on non-windows platform and path is not rooted, an extra path separator
+                            // has been removed and must be added on again.
+                            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !Path.IsPathRooted(path))
+                            {
+                                path = Path.PathSeparator + path;
+                            }
+#endif
+
                             if (DynamicApis.FileExists(path))
                             {
                                 return path;


### PR DESCRIPTION
This solves some cases related to finding the documentation XML file on Mac and Linux. Ref #152 .

- Move handling of external XML Docs for Mac into same block as other cases.
- Handle difference in `CodeBase` path between Windows and Linux/Mac.