### PR TITLE
Ignore inheritdoc on namespace base class

### DIFF
--- a/src/Namotion.Reflection.Tests/XmlDocsExtensionsTests.cs
+++ b/src/Namotion.Reflection.Tests/XmlDocsExtensionsTests.cs
@@ -884,5 +884,25 @@ namespace Namotion.Reflection.Tests
             Assert.Equal("My foo.", s1);
             Assert.Equal("My bar.", s2);
         }
+
+        [Fact]
+        public void When_inheritdoc_is_used_on_namespace_base_class_then_it_is_ignored()
+        {
+            //// Arrange
+            var t = typeof(InheritDocClass);
+
+            //// Act
+            var s = t.GetXmlDocsSummary();
+
+            //// Assert
+            Assert.False(string.IsNullOrWhiteSpace(s));
+        }
     }
+
+    /// <inheritdoc/>
+    /// <summary>
+    /// Foo.
+    /// </summary>
+    public class InheritDocClass
+    { }
 }

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -520,7 +520,7 @@ namespace Namotion.Reflection
                         continue;
                     }
 
-                    var baseType = member.DeclaringType.GetTypeInfo().BaseType;
+                    var baseType = member.DeclaringType?.GetTypeInfo().BaseType;
                     var baseMember = baseType?.GetTypeInfo().DeclaredMembers.SingleOrDefault(m => m.Name == member.Name);
                     if (baseMember != null)
                     {
@@ -545,7 +545,7 @@ namespace Namotion.Reflection
 
         private static void ProcessInheritdocInterfaceElements(this MemberInfo member, XElement child, XmlDocsOptions options)
         {
-            if (member.DeclaringType.GetTypeInfo().ImplementedInterfaces == null)
+            if (member.DeclaringType?.GetTypeInfo().ImplementedInterfaces == null)
             {
                 return;
             }


### PR DESCRIPTION
I'm trying to extract class/struct level docs from a library that places `<inheritdoc />` on all classes, even if they are a base class. This was causing issues as those types did not have a `DeclaringType` value