### PR TITLE
Fix crash for null element in list

### DIFF
--- a/src/Namotion.Reflection.Tests/ObjectExtensionsTests.cs
+++ b/src/Namotion.Reflection.Tests/ObjectExtensionsTests.cs
@@ -142,6 +142,17 @@ namespace Namotion.Reflection.Tests
             objectWithItemsListContainingSingleNonNullEntry.EnsureValidNullability();
         }
 
+        [Fact]
+        public void When_property_list_of_non_nullable_strings_contains_null_string_then_ValidateNullability_should_have_errors()
+        {
+            //// Arrange
+            var objectWithItemsListContainingSingleNullEntry = JsonConvert.DeserializeObject<SomethingWithListOfNonNullableStringItems>("{ \"Items\": [ null ] }");
+
+            //// Act and assert
+            Assert.NotNull(objectWithItemsListContainingSingleNullEntry);
+            Assert.NotEmpty(objectWithItemsListContainingSingleNullEntry.ValidateNullability());
+        }
+
         /// <summary>
         /// One of the reproduce cases for issue 39 - should not throw anything because a non-null string value is being deserialised into a property that is a list of non-nullable strings
         /// </summary>
@@ -152,6 +163,8 @@ namespace Namotion.Reflection.Tests
             var objectWithItemsListContainingSingleNullEntry = JsonConvert.DeserializeObject<SomethingWithListOfNonNullableStringItems>("{ \"Items\": [ null ] }");
 
             //// Act and assert
+            Assert.NotNull(objectWithItemsListContainingSingleNullEntry);
+            Assert.NotEmpty(objectWithItemsListContainingSingleNullEntry.ValidateNullability());
             Assert.Throws<InvalidOperationException>(() => objectWithItemsListContainingSingleNullEntry.EnsureValidNullability());
         }
 

--- a/src/Namotion.Reflection/ObjectExtensions.cs
+++ b/src/Namotion.Reflection/ObjectExtensions.cs
@@ -119,8 +119,18 @@ namespace Namotion.Reflection
                     {
                         if (itemType.Nullability == Nullability.NotNullable)
                         {
-                            throw new InvalidOperationException(
-                                "The object's nullability is invalid, item in enumerable.");
+                            if (errors != null)
+                            {
+                                errors.Add(itemType.Type.Name);
+                                if (stopFirstFail)
+                                {
+                                    return;
+                                }
+                            }
+                            else
+                            {
+                                throw new InvalidOperationException("The object's nullability is invalid, item in enumerable.");
+                            }
                         }
                     }
                     else

--- a/src/Namotion.Reflection/ObjectExtensions.cs
+++ b/src/Namotion.Reflection/ObjectExtensions.cs
@@ -92,13 +92,9 @@ namespace Namotion.Reflection
 
             if (checkedObjects != null)
             {
-                if (checkedObjects.Contains(obj))
+                if (!checkedObjects.Add(obj))
                 {
                     return;
-                }
-                else
-                {
-                    checkedObjects.Add(obj);
                 }
             }
 
@@ -142,9 +138,8 @@ namespace Namotion.Reflection
             else if (!type.TypeInfo.IsValueType)
             {
                 var properties = type.Type.GetContextualProperties();
-                for (int i = 0; i < properties.Length; i++)
+                foreach (var property in properties)
                 {
-                    var property = properties[i];
                     if (!property.PropertyType.IsValueType && property.CanRead && 
                         !property.IsAttributeDefined<CompilerGeneratedAttribute>(true))
                     {
@@ -164,7 +159,7 @@ namespace Namotion.Reflection
                                 else
                                 {
                                     throw new InvalidOperationException(
-                                        "The object's nullability is invalid, property: " + property.PropertyType.Type.FullName + "." + property.Name);
+                                                                        "The object's nullability is invalid, property: " + property.PropertyType.Type.FullName + "." + property.Name);
                                 }
                             }
                         }


### PR DESCRIPTION
See added test for currently failing test case - InvalidOperationException is always thrown by ValidateNullability instead of returning an error.

Please let me know if the error text can be improved.

This issue is very similar to #39 .