### PR TITLE
Fix test `When_type_is_in_NuGet_then_xml_docs_should_be_found` and tests in `Namotion.Reflection.Cecil.Tests` (Linux)

### DIFF
--- a/src/Namotion.Reflection.Cecil.Tests/XmlDocsExtensionsTests.cs
+++ b/src/Namotion.Reflection.Cecil.Tests/XmlDocsExtensionsTests.cs
@@ -46,7 +46,7 @@ namespace Namotion.Reflection.Cecil.Tests
         public void When_xml_docs_is_read_for_cecil_type_then_it_works()
         {
             // Arrange
-            var assemblyPath = typeof(XmlDocsExtensionsTests).Assembly.CodeBase!.Replace("file:///", string.Empty);
+            var assemblyPath = typeof(XmlDocsExtensionsTests).Assembly.Location;
             var xmlPath = assemblyPath.Replace(".dll", ".xml");
 
             var assembly = AssemblyDefinition.ReadAssembly(assemblyPath);
@@ -91,7 +91,7 @@ namespace Namotion.Reflection.Cecil.Tests
         public void When_xml_docs_is_enum_then_field_xml_docs_are_read()
         {
             // Arrange
-            var assemblyPath = typeof(XmlDocsExtensionsTests).Assembly.CodeBase!.Replace("file:///", string.Empty);
+            var assemblyPath = typeof(XmlDocsExtensionsTests).Assembly.Location;
             var xmlPath = assemblyPath.Replace(".dll", ".xml");
 
             var assembly = AssemblyDefinition.ReadAssembly(assemblyPath);
@@ -140,7 +140,7 @@ namespace Namotion.Reflection.Cecil.Tests
         public void WhenTypeInheritsFromGenericType_ThenMethodAndPropertyWithGenericParametersResolvesCorrectXml()
         {
             // Arrange
-            var assemblyPath = typeof(XmlDocsExtensionsTests).Assembly.CodeBase!.Replace("file:///", string.Empty);
+            var assemblyPath = typeof(XmlDocsExtensionsTests).Assembly.Location;
             var xmlPath = assemblyPath.Replace(".dll", ".xml");
 
             var assembly = AssemblyDefinition.ReadAssembly(assemblyPath);

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -1086,7 +1086,7 @@ namespace Namotion.Reflection
             try
             {
                 var json = DynamicApis.FileReadAllText(nuGetCacheFile);
-                var matches = Regex.Matches(json, $"\"((.*?){assemblyName.Name}((\\\\\\\\)|(////)){assemblyName.Version.ToString(3)})((\\\\\\\\)|(////))(.*?)\"", RegexOptions.IgnoreCase);
+                var matches = Regex.Matches(json, $"\"((.*?){assemblyName.Name}((\\\\\\\\)|/){assemblyName.Version.ToString(3)})((\\\\\\\\)|/)(.*?)\"", RegexOptions.IgnoreCase);
                 if (matches.Count > 0)
                 {
                     var files = DynamicApis.DirectoryGetAllFiles(matches[0].Groups[1].Value.Replace("\\\\", "\\").Replace("//", "/"), assemblyName.Name + ".xml");

--- a/src/Namotion.Reflection/XmlDocsExtensions.cs
+++ b/src/Namotion.Reflection/XmlDocsExtensions.cs
@@ -1077,6 +1077,14 @@ namespace Namotion.Reflection
             {
                 return GetXmlDocsPathFromNuGetCacheFile(nuGetCacheFile, assemblyName);
             }
+    
+            // This works for projects that have the artifacts output layout enabled:
+            // https://learn.microsoft.com/en-us/dotnet/core/sdk/artifacts-output
+            nuGetCacheFile = DynamicApis.PathCombine(assemblyDirectory.Replace("/bin/", "/obj/"), "../project.nuget.cache");
+            if (DynamicApis.FileExists(nuGetCacheFile))
+            {
+                return GetXmlDocsPathFromNuGetCacheFile(nuGetCacheFile, assemblyName);
+            }
 
             return null;
         }
@@ -1086,7 +1094,7 @@ namespace Namotion.Reflection
             try
             {
                 var json = DynamicApis.FileReadAllText(nuGetCacheFile);
-                var matches = Regex.Matches(json, $"\"((.*?){assemblyName.Name}((\\\\\\\\)|/){assemblyName.Version.ToString(3)})((\\\\\\\\)|/)(.*?)\"", RegexOptions.IgnoreCase);
+                var matches = Regex.Matches(json, $"\"((.*?){assemblyName.Name}((\\\\\\\\)|/).*?)((\\\\\\\\)|/)(.*?)\"", RegexOptions.IgnoreCase);
                 if (matches.Count > 0)
                 {
                     var files = DynamicApis.DirectoryGetAllFiles(matches[0].Groups[1].Value.Replace("\\\\", "\\").Replace("//", "/"), assemblyName.Name + ".xml");


### PR DESCRIPTION
Related to #33.

With the change suggested in comment https://github.com/RicoSuter/Namotion.Reflection/issues/33#issuecomment-1545572943 I am able to make the previously failing NuGet test succeed on Linux (`When_type_is_in_NuGet_then_xml_docs_should_be_found`).

![grafik](https://github.com/user-attachments/assets/5378c036-6634-4d27-8c94-353e4b6886c2)

![grafik](https://github.com/user-attachments/assets/bfeb26be-1f82-425c-81be-33414dbd2f61)

Tests in `Namotion.Reflection.Cecil.Tests` are also now executed successfully:

![grafik](https://github.com/user-attachments/assets/58684f25-d00f-43bf-953f-1644ca48fc10)
